### PR TITLE
refactor treasury contract

### DIFF
--- a/commons/storage.mligo
+++ b/commons/storage.mligo
@@ -1,23 +1,25 @@
 #import "types.mligo" "CommonTypes"
 
 module Types = struct
- (* The tokens that are valid within the contract  *)
- type valid_tokens = CommonTypes.Types.token list
+  (* The tokens that are valid within the contract  *)
+  type valid_tokens = CommonTypes.Types.token list
 
- (* The swaps of valid tokens that are accepted by the contract  *)
- type valid_swaps =  (string, CommonTypes.Types.swap) map
+  (* The swaps of valid tokens that are accepted by the contract  *)
+  type valid_swaps = (string, CommonTypes.Types.swap) map
 
- (* The current, most up to date exchange rates between tokens  *)
- type rates_current = (string, CommonTypes.Types.exchange_rate) big_map
+  (* The current, most up to date exchange rates between tokens  *)
+  type rates_current = (string, CommonTypes.Types.exchange_rate) big_map
 
- (* Historical rates for the contract - this can be a limited set after the PoC. i.e. last day or week *)
- type rates_historic = (string, CommonTypes.Types.exchange_rate list) big_map
+  (* Historical rates for the contract - this can be a limited set after the PoC. i.e. last day or week *)
+  type rates_historic = (string, CommonTypes.Types.exchange_rate list) big_map
 
-  (* The deposited tokens *)
-  type treasury = (address, CommonTypes.Types.token_amount) big_map
+  type treasury_value = {
+    base_token : CommonTypes.Types.token_amount;
+    swapped_token : CommonTypes.Types.token_amount;  
+  }
 
-  (* The swapped tokens *)
-  type swapped_treasury = (address, CommonTypes.Types.token_amount) big_map
+  (* The treasury storage *)
+  type treasury = (address, treasury_value) big_map
 
   type t = {
     valid_tokens : valid_tokens;
@@ -25,7 +27,6 @@ module Types = struct
     rates_current : rates_current;
     rates_historic : rates_historic;
     treasury : treasury;
-    swapped_treasury : swapped_treasury;
   }
 
 end

--- a/commons/types.mligo
+++ b/commons/types.mligo
@@ -45,12 +45,12 @@ module Types = struct
   }
 
   type deposit = {
-    deposited_token_amount : token_amount;
+    deposited_token : token_amount;
     exchange_rate : exchange_rate;
   }
 
   type redeem = {
-    redeemed_token_amount : token_amount;
+    redeemed_token : token_amount;
     exchange_rate : exchange_rate;
   }
 

--- a/data/treasury/storage.mligo
+++ b/data/treasury/storage.mligo
@@ -1,4 +1,1 @@
-{
-  treasury = (Big_map.empty : Storage.Types.treasury);
-  swapped_treasury = (Big_map.empty : Storage.Types.swapped_treasury);
-}
+(Big_map.empty : CommonStorage.Types.treasury)

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -58,10 +58,10 @@ deposit_treasury_contract () {
   quote_token_value=$(jq '.exchange_rate.quote.value' $1 | xargs)
   quote_token_timestamp=$(jq '.exchange_rate.quote.timestamp' $1 | xargs)
  
-  deposited_token="Pair (Pair \"$deposit_address\" \"$deposit_token_name\") $deposit_value"
+  deposited_token="Pair $deposit_value (Pair (Some \"$deposit_address\") \"$deposit_token_name\")"
 
-  base_value="Pair (Pair (Pair \"$base_token_address\" \"$base_token_name\") $base_token_value) \"$base_token_timestamp\""
-  quote_value="Pair (Pair (Pair \"$quote_token_address\" \"$quote_token_name\") $quote_token_value) \"$quote_token_timestamp\""
+  base_value="Pair (Pair (Pair (Some \"$base_token_address\") \"$base_token_name\") $base_token_value) \"$base_token_timestamp\""
+  quote_value="Pair (Pair (Pair (Some \"$quote_token_address\") \"$quote_token_name\") $quote_token_value) \"$quote_token_timestamp\""
   exchange_rate="Pair ($base_value) ($quote_value)"
 
   tezos-client --endpoint $RPC_NODE transfer 0 from bob to treasury \
@@ -84,13 +84,13 @@ redeem_treasury_contract () {
   quote_token_value=$(jq '.exchange_rate.quote.value' $1 | xargs)
   quote_token_timestamp=$(jq '.exchange_rate.quote.timestamp' $1 | xargs)
  
-  redeemed_token="Pair (Pair \"$redeem_address\" \"$redeem_token_name\") $redeem_value"
+  redeemed_token="Pair $redeem_value (Pair (Some \"$redeem_address\") \"$redeem_token_name\")"
 
-  base_value="Pair (Pair (Pair \"$base_token_address\" \"$base_token_name\") $base_token_value) \"$base_token_timestamp\""
-  quote_value="Pair (Pair (Pair \"$quote_token_address\" \"$quote_token_name\") $quote_token_value) \"$quote_token_timestamp\""
+  base_value="Pair (Pair (Pair (Some \"$base_token_address\") \"$base_token_name\") $base_token_value) \"$base_token_timestamp\""
+  quote_value="Pair (Pair (Pair (Some \"$quote_token_address\") \"$quote_token_name\") $quote_token_value) \"$quote_token_timestamp\""
   exchange_rate="Pair ($base_value) ($quote_value)"
 
-  tezos-client --endpoint $RPC_NODE transfer 0 from bob to treasury \
+  tezos-client --endpoint $RPC_NODE transfer 0 from alice to treasury \
   --entrypoint redeem --arg "Pair ($exchange_rate) ($redeemed_token)" \
   --burn-cap 2
 }

--- a/slip/0slip.mligo
+++ b/slip/0slip.mligo
@@ -25,12 +25,12 @@ type parameter =
 let add_swap_order (o : CommonTypes.Types.swap_order) (s : storage ) : result =
   let address = Tezos.sender in
   let rate = Pricing.Rates.get_rate (o) (s) in
-  let deposited_token_amount : CommonTypes.Types.token_amount =  {
+  let deposited_token : CommonTypes.Types.token_amount =  {
          token = o.swap.from;
          amount = o.from_amount;
      } in
   let deposit : CommonTypes.Types.deposit = {
-     deposited_token_amount = deposited_token_amount;
+     deposited_token = deposited_token;
      exchange_rate = rate;
   }  in
   let s = Treasury.Utils.deposit address deposit s in

--- a/treasury/errors.mligo
+++ b/treasury/errors.mligo
@@ -1,3 +1,5 @@
 let incorrect_address : string = "This address has not swapped any tokens"
 
-let greater_than_owned_token : string = "This redeemed tokens are greater than the owned tokens"
+let greater_than_original_token : string = "This redeemed base tokens are greater than the owned base tokens"
+
+let greater_than_swapped_token : string = "This redeemed quote tokens are greater than the owned quote tokens"

--- a/treasury/main.mligo
+++ b/treasury/main.mligo
@@ -1,0 +1,18 @@
+#import "../commons/types.mligo" "CommonTypes" 
+#import "../commons/storage.mligo" "CommonStorage"
+#import "treasury.mligo" "Treasury"
+
+type storage = CommonStorage.Types.treasury
+type action = 
+| Deposit of CommonTypes.Types.deposit
+| Redeem of CommonTypes.Types.redeem
+
+let main (action, storage : action * storage) = 
+  let address = Tezos.get_sender () in 
+  match action with 
+  | Deposit deposited_value -> 
+    let storage = Treasury.Utils.deposit address deposited_value storage in 
+    (([] : operation list), storage)
+  | Redeem redeemed_value -> 
+    let storage = Treasury.Utils.redeem address redeemed_value storage in 
+    (([] : operation list), storage) 

--- a/treasury/treasury.mligo
+++ b/treasury/treasury.mligo
@@ -6,96 +6,84 @@ module Utils = struct
   type exchange_rate = CommonTypes.Types.exchange_rate
   type storage = CommonStorage.Types.t
   type token_amount = CommonTypes.Types.token_amount
+  type treasury_value = CommonStorage.Types.treasury_value
 
-  (* Get the number of swapped tokens based on the current exchange_rate *)
-  let get_swapped_value (token : token_amount) (exchange_rate : exchange_rate) : token_amount  =
+  (* Get the number of swapped tokens based on the current exchange xsrate *)
+  let get_swapped_token (token : token_amount) (exchange_rate : exchange_rate) : token_amount  =
     let { quote; base } = exchange_rate in
     let quote_value = quote.value in
     let base_value = base.value in
     let updated_amount = (token.amount * quote_value) / base_value in
-    { token =  quote.token; amount = updated_amount;  }
+    { token = quote.token; amount = updated_amount }
 
-  (* A person deposits an amount of tokens into storage for swapping *)
-  let deposit_treasury (deposit_address : address) (deposited_token : token_amount) (treasury : CommonStorage.Types.treasury) =
-    match Big_map.get_and_update
-      deposit_address
-      (None : token_amount option)
-      treasury
-    with
-    | (None, treasury) ->
-      Big_map.add deposit_address deposited_token treasury
-    | (Some old_token, treasury) ->
-      let updated_amount = old_token.amount + deposited_token.amount in
-      Big_map.add deposit_address { old_token with amount = updated_amount } treasury
+  let get_deposited_base_token (base_token : token_amount) (deposited_token : token_amount) = 
+    let base_token_amount = base_token.amount + deposited_token.amount in
+    { base_token with amount = base_token_amount }
 
-  (* This swapped tokens are owned by the given person *)
-  let deposit_swapped_token
-    (deposit_address : address)
-    (deposited_token : token_amount)
-    (exchange_rate : exchange_rate)
-    (swapped_treasury : CommonStorage.Types.swapped_treasury) =
-      let swapped_token = get_swapped_value deposited_token exchange_rate in
+  let get_deposited_swap_token (swapped_token : token_amount) (deposited_token : token_amount) (exchange_rate : exchange_rate) =
+    let deposited_swap_token = get_swapped_token deposited_token exchange_rate in 
+    let swapped_token_amount = swapped_token.amount + deposited_swap_token.amount in 
+    { swapped_token with amount = swapped_token_amount }
+
+  (* A person deposits an amount of tokens into storage and get the corresponding swapped tokens *)
+  let deposit_treasury 
+    (deposit_address : address) 
+    (deposited_token : token_amount) 
+    (exchange_rate : exchange_rate) 
+    (treasury : CommonStorage.Types.treasury) =
       match Big_map.get_and_update
         deposit_address
-        (None : token_amount option)
-        swapped_treasury
+        (None : treasury_value option)
+        treasury
       with
-      | (None, swapped_treasury) ->
-        Big_map.add deposit_address swapped_token swapped_treasury
-      | (Some old_token, swapped_treasury) ->
-        let updated_amount = old_token.amount + swapped_token.amount in
-        Big_map.add deposit_address { old_token with amount = updated_amount } swapped_treasury
+      | (None, treasury) ->
+        let swapped_token = get_swapped_token deposited_token exchange_rate in  
+        Big_map.add deposit_address { base_token = deposited_token; swapped_token = swapped_token } treasury
+      | (Some old_value, treasury) ->
+        let base_token = get_deposited_base_token old_value.base_token deposited_token in 
+        let swapped_token = get_deposited_swap_token old_value.swapped_token deposited_token exchange_rate in 
+        Big_map.add deposit_address { base_token = base_token; swapped_token = swapped_token } treasury
 
   let deposit (deposit_address : address) (deposited_value : CommonTypes.Types.deposit) (storage : CommonStorage.Types.t) =
-    let { deposited_token_amount; exchange_rate } = deposited_value in
-    let treasury = storage.treasury in
-    let swapped_treasury = storage.swapped_treasury in
-    let treasury = deposit_treasury deposit_address deposited_token_amount treasury in
-    let swapped_treasury = deposit_swapped_token deposit_address deposited_token_amount exchange_rate swapped_treasury in
-    { storage with  treasury = treasury; swapped_treasury = swapped_treasury }
+    let { deposited_token; exchange_rate } = deposited_value in
+    let treasury = deposit_treasury deposit_address deposited_token exchange_rate storage in
+    { storage with treasury = treasury }
 
-  (* A person redeems an amount of tokens from storage *)
-  let redeem_treasury (redeem_address : address) (redeemed_token : token_amount) (treasury : CommonStorage.Types.treasury) =
+  let get_redeemed_base_token (base_token : token_amount) (redeemed_token : token_amount) = 
+    if redeemed_token.amount > base_token.amount then 
+      (failwith TreasuryErrors.greater_than_original_token : token_amount)
+    else 
+      let base_token_amount = abs (base_token.amount - redeemed_token.amount) in 
+      { base_token with amount = base_token_amount }
+
+  let get_redeemed_swap_token (swapped_token : token_amount) (redeemed_token : token_amount) (exchange_rate : exchange_rate) = 
+    let redeemed_swap_token = get_swapped_token redeemed_token exchange_rate in 
+    if redeemed_swap_token.amount > swapped_token.amount then 
+      (failwith TreasuryErrors.greater_than_swapped_token : token_amount)
+    else 
+      let swapped_token_amount = abs (swapped_token.amount - redeemed_swap_token.amount) in 
+      { swapped_token with amount = swapped_token_amount }
+
+  (* A person redeems an amount of tokens from storage, i.e it is the result of partial swap *)
+  let redeem_treasury 
+    (redeem_address : address) 
+    (redeemed_token : token_amount)
+    (exchange_rate : exchange_rate) 
+    (treasury : CommonStorage.Types.treasury) =
     match Big_map.get_and_update
       redeem_address
-      (None : token_amount option)
+      (None : treasury_value option)
       treasury
     with
     | (None, treasury) ->
       (failwith TreasuryErrors.incorrect_address : CommonStorage.Types.treasury)
-    | (Some old_token, treasury) ->
-      if redeemed_token.amount > old_token.amount then
-        (failwith TreasuryErrors.greater_than_owned_token : CommonStorage.Types.treasury)
-      else
-        let updated_amount = abs (old_token.amount - redeemed_token.amount) in
-        Big_map.add redeem_address { old_token with amount = updated_amount } treasury
-
-  (* This swapped tokens are redeemed from the given person *)
-  let redeem_swapped_token
-    (redeem_address : address)
-    (redeemed_token : token_amount)
-    (exchange_rate : exchange_rate)
-    (swapped_treasury : CommonStorage.Types.swapped_treasury) =
-      let swapped_token = get_swapped_value redeemed_token exchange_rate in
-      match Big_map.get_and_update
-        redeem_address
-        (None : token_amount option)
-        swapped_treasury
-      with
-      | (None, swapped_treasury) ->
-        (failwith TreasuryErrors.incorrect_address : CommonStorage.Types.swapped_treasury)
-      | (Some old_token, swapped_treasury) ->
-        if swapped_token.amount > old_token.amount then
-          (failwith TreasuryErrors.greater_than_owned_token : CommonStorage.Types.swapped_treasury)
-        else
-          let updated_amount = abs (old_token.amount - swapped_token.amount) in
-          Big_map.add redeem_address { old_token with amount = updated_amount } swapped_treasury
+    | (Some old_value, treasury) ->
+      let base_token = get_redeemed_base_token old_value.base_token redeemed_token in 
+      let swapped_token = get_redeemed_swap_token old_value.swapped_token redeemed_token exchange_rate in
+      Big_map.add redeem_address { base_token = base_token; swapped_token = swapped_token } treasury
 
   let redeem (redeem_address : address) (redeemed_value : CommonTypes.Types.redeem) (storage : CommonStorage.Types.t) =
-    let { redeemed_token_amount; exchange_rate } = redeemed_value in
-    let treasury = storage.treasury in
-    let swapped_treasury  = storage.swapped_treasury in
-    let treasury = redeem_treasury redeem_address redeemed_token_amount treasury in
-    let swapped_treasury = redeem_swapped_token redeem_address redeemed_token_amount exchange_rate swapped_treasury in
-    { treasury = treasury; swapped_treasury = swapped_treasury }
+    let { redeemed_token; exchange_rate } = redeemed_value in
+    let treasury = redeem_treasury redeem_address redeemed_token exchange_rate storage in
+    { storage with treasury = treasury }
 end


### PR DESCRIPTION
I change the treasury contract storage into a single big_map `type treasury = (address, treasury_value) big_map`