### PR TITLE
propagate tokens transfers operations

### DIFF
--- a/batcher/batcher.mligo
+++ b/batcher/batcher.mligo
@@ -100,12 +100,13 @@ let deposit (external_order: Types.Types.external_swap_order) (storage : storage
   in
   let updated_storage = { ticked_storage with batches = updated_batches } in
   (* FIXME We should take the deposit before updating the batch ideally.  That way we can be sure we actually have the token we are trying to swap *)
-  let storage_after_treasury_update = Treasury.deposit order.trader order.swap.from updated_storage in
-  no_op (storage_after_treasury_update)
+  let (tokens_transfer_op, storage_after_treasury_update) = Treasury.deposit order.trader order.swap.from updated_storage in
+  ([tokens_transfer_op], storage_after_treasury_update)
 
 let redeem (storage : storage) : result =
   let holder = Tezos.get_sender () in
-  no_op(Treasury.redeem holder storage)
+  let (tokens_transfer_ops, new_storage) = Treasury.redeem holder storage in
+  (tokens_transfer_ops, new_storage)
 
 
 let move_current_to_previous_if_finalized (storage : storage) : storage = 


### PR DESCRIPTION
As we discussed on slack, the redemption didn't work because we didn't propagate the operations we created in the contract. And I realized that we didn't do it for the deposits either, because the deposit was recoded on the front side instead of using the contract code.

I don't know which is better between doing token transfers on the front side or on the contract side, that said we should have the same solution for deposits and redemptions, so I haven't yet removed the redundant code on the front side (in deposit.tx) so that we can discuss the solution that we will adopt.

Any suggestion is welcome, even nitpicking ones