### PR TITLE
Fix the RPC node in kathmandunet docker

### DIFF
--- a/Dockerfile.price.kathmandunet
+++ b/Dockerfile.price.kathmandunet
@@ -4,7 +4,7 @@ RUN apk update &&\
     apk add bash &&\
     apk add curl &&\
     apk add jq &&\
-    tezos-client --endpoint https://kathmandunet.tezos.marigold.dev config update
+    tezos-client --endpoint https://kathmandunet.ecadinfra.com config update
 
 WORKDIR /etc/run
 


### PR DESCRIPTION
## Problems
It can't connect to the `Kathmandunet` by using the RPC node of Marigold.

## Solutions
I change it to [https://kathmandunet.ecadinfra.com](https://kathmandunet.ecadinfra.com) in Dockerfile.kathmandunet.
