### PR TITLE
fix broken tests

### DIFF
--- a/batcher/errors.mligo
+++ b/batcher/errors.mligo
@@ -21,7 +21,7 @@ let insufficient_token_holding_for_decrease : nat = 109n
 
 let no_treasury_holding_for_address : nat = 110n
 
-let order_pair_doesnt_match = 111n
+let order_pair_doesnt_match = "Not the correct token pair"
 
 let tokens_do_not_match = 112n
 

--- a/batcher/test/util.mligo
+++ b/batcher/test/util.mligo
@@ -107,5 +107,6 @@ let deposit (order : order)
   (contract : (Batcher.entrypoint, Batcher.storage) originated)
   (qty: tez)
   () =
-  let deposit = Deposit order in
+  let converted_order = Batcher.order_to_external order in
+  let deposit = Deposit converted_order in
   Breath.Contract.transfert_to contract deposit qty

--- a/batcher/types.mligo
+++ b/batcher/types.mligo
@@ -200,15 +200,26 @@ module Utils = struct
     }
 
 
-  let parse_side
-    (order_side : nat) : Types.side =
-      if order_side = 0n then BUY
-      else SELL
+  let nat_to_side
+  (order_side : nat) : Types.side =
+    if order_side = 0n then BUY
+    else 
+      if order_side = 1n then SELL
+      else failwith Errors.unable_to_parse_side_from_external_order
 
-  let parse_tolerance (tolerance : nat) : Types.tolerance =
+  let nat_to_tolerance (tolerance : nat) : Types.tolerance =
     if tolerance = 0n then MINUS 
     else if tolerance = 1n then EXACT
     else if tolerance = 2n then PLUS
     else failwith Errors.unable_to_parse_tolerance_from_external_order
+
+  let side_to_nat (side : Types.side) : nat = match side with
+    | BUY -> 9n
+    | SELL -> 1n
+
+  let tolerance_to_nat (tolerance : Types.tolerance) : nat = match tolerance with
+    | MINUS -> 0n
+    | EXACT -> 1n
+    | PLUS -> 2n
 end
 


### PR DESCRIPTION
This PR fix this problem https://github.com/marigold-dev/batcher/issues/159

There was several in fact : the errors in errors.mligo are now only nat, but there was string at first and the Breath.Expect.fail_with_message function use in many tests depend of that, the external_swap_order was not propagated on the tests, so i fix all those.

The tests still exceed the constant maximum operation size, but thats another problem, please don't forget to try to compile tests when you are updating the codebase.