### PR TITLE
Reset to the original codebase

### DIFF
--- a/batcher-ui/src/app.tsx
+++ b/batcher-ui/src/app.tsx
@@ -16,7 +16,7 @@ export const initialStateConfig = {
 export async function getInitialState(): Promise<any> {
   return {
     wallet: null,
-    userAddress: localStorage.getItem('address') ?? null,
+    userAddress: null,
     settings: defaultSettings,
   };
 }

--- a/batcher-ui/src/components/RightContent/index.tsx
+++ b/batcher-ui/src/components/RightContent/index.tsx
@@ -69,13 +69,11 @@ const GlobalHeaderRight: React.FC = () => {
       Tezos.setWalletProvider(updatedWallet);
       const activeAccount = await updatedWallet.client.getActiveAccount();
       const userAddress = activeAccount ? await updatedWallet.getPKH() : null;
-      localStorage.setItem('address', userAddress);
       setInitialState({ ...initialState, wallet: updatedWallet, userAddress });
     }
   };
 
   const disconnectWallet = async () => {
-    localStorage.removeItem('address');
     setInitialState({ ...initialState, wallet: null, userAddress: null });
   };
 


### PR DESCRIPTION
## Depends

- [x] #204

## Warnings
- I changed the connection state to the original version. In this situation, we need to connect to the wallet again when we reload the page. 
- I try to persist the wallet when we reload the page by using the `localStorage`. However, when I stringify the `wallet` in the `initialState` and include this in localStorage, and after that, I get it from the `localStorage` and parse it but I can't use it in `TezosToolKit`.
```
JSON.parse(localStorage.getItem('wallet'))
```
It shows errors when I try to swap tokens. I think the reason is that the parsed data is different from the original data when considering types.
