### PR TITLE
327 move fees

### DIFF
--- a/batcher/batcher-ghostnet.tz
+++ b/batcher/batcher-ghostnet.tz
@@ -355,15 +355,18 @@
                                    IF { DROP 2 ; PUSH nat 133 ; FAILWITH }
                                       { DUP 2 ;
                                         CDR ;
-                                        CAR ;
-                                        CDR ;
                                         CDR ;
                                         DUP 3 ;
+                                        CDR ;
+                                        CAR ;
+                                        CDR ;
+                                        CDR ;
+                                        DUP 4 ;
                                         CAR ;
                                         CDR ;
                                         CDR ;
                                         CAR ;
-                                        DUP 3 ;
+                                        DUP 4 ;
                                         CAR ;
                                         DUP ;
                                         CAR ;
@@ -379,9 +382,7 @@
                                         GT ;
                                         IF { DIG 3 ; DROP ; PUSH nat 127 ; FAILWITH }
                                            { PUSH bool False ;
-                                             DUP 8 ;
-                                             CDR ;
-                                             CDR ;
+                                             DUP 7 ;
                                              ITER { CDR ;
                                                     SWAP ;
                                                     DUP 2 ;
@@ -420,9 +421,7 @@
                                                     AND ;
                                                     OR } ;
                                              PUSH bool False ;
-                                             DUP 9 ;
-                                             CDR ;
-                                             CDR ;
+                                             DUP 8 ;
                                              ITER { CDR ;
                                                     SWAP ;
                                                     DUP 2 ;
@@ -463,9 +462,7 @@
                                              AND ;
                                              IF { PUSH nat 0 }
                                                 { PUSH bool False ;
-                                                  DUP 8 ;
-                                                  CDR ;
-                                                  CDR ;
+                                                  DUP 7 ;
                                                   ITER { CDR ;
                                                          SWAP ;
                                                          DUP 2 ;
@@ -504,9 +501,7 @@
                                                          AND ;
                                                          OR } ;
                                                   PUSH bool False ;
-                                                  DUP 9 ;
-                                                  CDR ;
-                                                  CDR ;
+                                                  DUP 8 ;
                                                   ITER { CDR ;
                                                          SWAP ;
                                                          DUP 2 ;
@@ -548,9 +543,7 @@
                                                   IF { PUSH nat 1 } { PUSH nat 2 } } ;
                                              DIG 4 ;
                                              SWAP ;
-                                             DUP 8 ;
-                                             CDR ;
-                                             CDR ;
+                                             DUP 7 ;
                                              SIZE ;
                                              ADD ;
                                              COMPARE ;
@@ -573,40 +566,37 @@
                                            { SWAP ; PUSH string "/" ; CONCAT ; DIG 2 ; CONCAT } ;
                                         GET ;
                                         IF_NONE
-                                          { DUP 5 ;
-                                            CDR ;
-                                            CDR ;
-                                            DUP ;
-                                            DUP 4 ;
+                                          { DUP 4 ;
+                                            DUP 3 ;
                                             GET 3 ;
                                             GET ;
                                             IF_NONE
-                                              { DUP 3 ; DIG 3 ; GET 3 ; SWAP ; SOME ; SWAP ; UPDATE }
-                                              { DUP 4 ;
+                                              { DIG 3 ; DUP 3 ; DIG 3 ; GET 3 ; SWAP ; SOME ; SWAP ; UPDATE }
+                                              { DUP 3 ;
                                                 GET 8 ;
                                                 DUP 2 ;
                                                 GET 8 ;
                                                 COMPARE ;
                                                 EQ ;
-                                                DUP 5 ;
+                                                DUP 4 ;
                                                 GET 7 ;
                                                 DUP 3 ;
                                                 GET 7 ;
                                                 COMPARE ;
                                                 EQ ;
-                                                DUP 6 ;
+                                                DUP 5 ;
                                                 GET 5 ;
                                                 DUP 4 ;
                                                 GET 5 ;
                                                 COMPARE ;
                                                 EQ ;
-                                                DUP 7 ;
+                                                DUP 6 ;
                                                 GET 3 ;
                                                 DUP 5 ;
                                                 GET 3 ;
                                                 COMPARE ;
                                                 EQ ;
-                                                DIG 7 ;
+                                                DIG 6 ;
                                                 CAR ;
                                                 DIG 5 ;
                                                 CAR ;
@@ -616,7 +606,7 @@
                                                 AND ;
                                                 AND ;
                                                 AND ;
-                                                IF {} { DROP ; PUSH nat 115 ; FAILWITH } } ;
+                                                IF { DIG 2 } { DIG 2 ; DROP ; PUSH nat 115 ; FAILWITH } } ;
                                             DUP ;
                                             DUP 3 ;
                                             GET 3 ;
@@ -667,12 +657,7 @@
                                             CAR ;
                                             CAR ;
                                             GET 3 ;
-                                            PAIR ;
                                             SWAP ;
-                                            DUP 2 ;
-                                            CAR ;
-                                            DIG 2 ;
-                                            CDR ;
                                             DIG 3 ;
                                             DUP 5 ;
                                             GET 8 ;
@@ -704,7 +689,7 @@
                                             SWAP ;
                                             UPDATE ;
                                             PAIR }
-                                          { DROP 5 ; PUSH nat 116 ; FAILWITH } ;
+                                          { DROP 6 ; PUSH nat 116 ; FAILWITH } ;
                                         UNPAIR ;
                                         DUP 3 ;
                                         DIG 3 ;
@@ -1030,29 +1015,19 @@
                               COMPARE ;
                               LT ;
                               IF { DROP 6 ; PUSH nat 113 ; FAILWITH }
-                                 { DUP 2 ;
-                                   SWAP ;
-                                   COMPARE ;
+                                 { COMPARE ;
                                    GT ;
-                                   IF { DROP 5 ; PUSH nat 130 ; FAILWITH }
-                                      { DUP 5 ;
-                                        CAR ;
-                                        CAR ;
-                                        CDR ;
-                                        CAR ;
-                                        DUP 6 ;
+                                   IF { DROP 4 ; PUSH nat 130 ; FAILWITH }
+                                      { DUP 4 ;
                                         CAR ;
                                         CAR ;
                                         CAR ;
                                         CDR ;
+                                        DUP ;
                                         CDR ;
-                                        DUP 7 ;
+                                        DUP 2 ;
                                         CAR ;
-                                        CAR ;
-                                        CAR ;
-                                        CDR ;
-                                        CAR ;
-                                        DUP 6 ;
+                                        DUP 5 ;
                                         UNPAIR ;
                                         DUP ;
                                         DUP 3 ;
@@ -1064,19 +1039,13 @@
                                         IF_NONE { PUSH nat 0 } {} ;
                                         GET ;
                                         IF_NONE
-                                          { DROP ;
-                                            DUP 5 ;
-                                            CAR ;
-                                            CAR ;
-                                            CAR ;
-                                            CDR ;
-                                            PUSH nat 0 ;
+                                          { PUSH nat 0 ;
                                             DUP 2 ;
                                             CAR ;
                                             ITER { CDR ; DUP 2 ; DUP 2 ; COMPARE ; GT ; IF { SWAP ; DROP } { DROP } } ;
                                             PUSH nat 1 ;
                                             ADD ;
-                                            DUP 5 ;
+                                            DUP 4 ;
                                             PUSH nat 0 ;
                                             PUSH nat 0 ;
                                             PUSH nat 0 ;
@@ -1086,7 +1055,7 @@
                                             PUSH nat 0 ;
                                             PUSH nat 0 ;
                                             PAIR 8 ;
-                                            DIG 5 ;
+                                            DIG 4 ;
                                             RIGHT
                                               (or (pair (pair timestamp
                                                               (pair (pair nat nat nat)
@@ -1122,25 +1091,25 @@
                                                { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                                             UPDATE ;
                                             UPDATE 1 }
-                                          { DUP ;
+                                          { DUP 6 ;
+                                            CAR ;
+                                            CAR ;
+                                            CDR ;
+                                            CAR ;
+                                            DUP 2 ;
                                             GET 3 ;
                                             IF_LEFT
-                                              { DIG 2 ;
+                                              { SWAP ;
                                                 DROP ;
                                                 IF_LEFT
                                                   { DROP 2 ;
-                                                    DUP 5 ;
-                                                    CAR ;
-                                                    CAR ;
-                                                    CAR ;
-                                                    CDR ;
                                                     PUSH nat 0 ;
                                                     DUP 2 ;
                                                     CAR ;
                                                     ITER { CDR ; DUP 2 ; DUP 2 ; COMPARE ; GT ; IF { SWAP ; DROP } { DROP } } ;
                                                     PUSH nat 1 ;
                                                     ADD ;
-                                                    DUP 5 ;
+                                                    DUP 4 ;
                                                     PUSH nat 0 ;
                                                     PUSH nat 0 ;
                                                     PUSH nat 0 ;
@@ -1150,7 +1119,7 @@
                                                     PUSH nat 0 ;
                                                     PUSH nat 0 ;
                                                     PAIR 8 ;
-                                                    DIG 5 ;
+                                                    DIG 4 ;
                                                     RIGHT
                                                       (or (pair (pair timestamp
                                                                       (pair (pair nat nat nat)
@@ -1186,14 +1155,14 @@
                                                        { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                                                     UPDATE ;
                                                     UPDATE 1 }
-                                                  { DIG 3 ; DROP 2 ; DUP 5 ; CAR ; CAR ; CAR ; CDR } }
-                                              { DUP 3 ;
+                                                  { DIG 3 ; DROP 2 ; SWAP } }
+                                              { DUP 2 ;
                                                 INT ;
                                                 ADD ;
                                                 DIG 4 ;
                                                 COMPARE ;
                                                 GE ;
-                                                IF { DUP ;
+                                                IF { DUP 2 ;
                                                      GET 3 ;
                                                      IF_LEFT
                                                        { SWAP ;
@@ -1202,7 +1171,7 @@
                                                          IF_LEFT
                                                            { DROP ; PUSH nat 105 ; FAILWITH }
                                                            { DROP ; PUSH nat 105 ; FAILWITH } }
-                                                       { DIG 2 ;
+                                                       { SWAP ;
                                                          INT ;
                                                          DUP 2 ;
                                                          ADD ;
@@ -1216,16 +1185,8 @@
                                                                  (pair (pair string string) (pair int int) timestamp)) ;
                                                          LEFT timestamp ;
                                                          UPDATE 3 } ;
-                                                     DUP 5 ;
-                                                     CAR ;
-                                                     CAR ;
-                                                     CAR ;
-                                                     CDR ;
-                                                     DUP 6 ;
-                                                     CAR ;
-                                                     CAR ;
-                                                     CAR ;
-                                                     CDR ;
+                                                     DUP 2 ;
+                                                     DUP 3 ;
                                                      CDR ;
                                                      DUP 3 ;
                                                      SOME ;
@@ -1233,11 +1194,7 @@
                                                      CAR ;
                                                      UPDATE ;
                                                      UPDATE 2 ;
-                                                     DUP 6 ;
-                                                     CAR ;
-                                                     CAR ;
-                                                     CAR ;
-                                                     CDR ;
+                                                     DIG 2 ;
                                                      CAR ;
                                                      DUP 3 ;
                                                      CAR ;
@@ -1253,7 +1210,7 @@
                                                         { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                                                      UPDATE ;
                                                      UPDATE 1 }
-                                                   { SWAP ; DROP ; DUP 5 ; CAR ; CAR ; CAR ; CDR } } } ;
+                                                   { DROP ; SWAP } } } ;
                                         SWAP ;
                                         DUP ;
                                         GET 3 ;
@@ -1265,13 +1222,13 @@
                                              IF_LEFT
                                                { IF_LEFT { DROP ; PUSH bool False } { DROP ; PUSH bool False } }
                                                { DROP ; PUSH bool True } ;
-                                             IF { DIG 3 ; DROP }
-                                                { DUP 6 ;
+                                             IF { DIG 2 ; DROP }
+                                                { DUP 5 ;
                                                   CDR ;
                                                   CAR ;
                                                   CDR ;
                                                   CDR ;
-                                                  DIG 4 ;
+                                                  DIG 3 ;
                                                   UNPAIR ;
                                                   DUP ;
                                                   DUP 3 ;
@@ -1288,13 +1245,13 @@
                                                   VIEW "getPrice" (pair timestamp nat) ;
                                                   IF_NONE { PUSH nat 124 ; FAILWITH } {} ;
                                                   CAR ;
-                                                  DUP 6 ;
+                                                  DUP 5 ;
                                                   CAR ;
                                                   CAR ;
                                                   CDR ;
                                                   CAR ;
                                                   INT ;
-                                                  DUP 7 ;
+                                                  DUP 6 ;
                                                   CDR ;
                                                   CAR ;
                                                   CAR ;
@@ -1306,8 +1263,8 @@
                                                   COMPARE ;
                                                   LT ;
                                                   IF {} { PUSH nat 120 ; FAILWITH } } ;
-                                             DUP 5 ;
-                                             DIG 5 ;
+                                             DUP 4 ;
+                                             DIG 4 ;
                                              CAR ;
                                              DUP ;
                                              CAR ;
@@ -1327,6 +1284,9 @@
                                              CAR ;
                                              CDR ;
                                              ADD ;
+                                             DUP 3 ;
+                                             CDR ;
+                                             CDR ;
                                              DUP 7 ;
                                              GET 5 ;
                                              PUSH nat 0 ;
@@ -1357,23 +1317,20 @@
                                                        EQ ;
                                                        IF { UNIT ; RIGHT (or unit unit) } { PUSH nat 107 ; FAILWITH } } } ;
                                              SENDER ;
-                                             DUP 6 ;
-                                             CDR ;
-                                             CDR ;
-                                             DUP 11 ;
+                                             DUP 10 ;
                                              CAR ;
                                              DUP ;
                                              CAR ;
                                              CAR ;
                                              DUP 2 ;
                                              CDR ;
-                                             DUP 4 ;
+                                             DUP 7 ;
                                              DUP 3 ;
                                              GET 3 ;
                                              GET ;
                                              IF_NONE
-                                               { DROP 4 ; PUSH nat 110 ; FAILWITH }
-                                               { DIG 4 ;
+                                               { SWAP ; DIG 2 ; DIG 6 ; DROP 4 ; PUSH nat 110 ; FAILWITH }
+                                               { DIG 7 ;
                                                  DUP 3 ;
                                                  GET 3 ;
                                                  GET ;
@@ -1476,7 +1433,7 @@
                                              PUSH bool False ;
                                              DIG 2 ;
                                              DIG 3 ;
-                                             DIG 10 ;
+                                             DIG 9 ;
                                              CAR ;
                                              DIG 4 ;
                                              DUP 7 ;
@@ -1687,16 +1644,16 @@
                                                           SWAP ;
                                                           UPDATE 14 } } ;
                                                   DUP 6 ;
-                                                  DUP 7 ;
+                                                  DIG 6 ;
                                                   CAR ;
                                                   DUP ;
                                                   CAR ;
                                                   DUP ;
                                                   CAR ;
-                                                  DUP 12 ;
-                                                  DIG 12 ;
+                                                  DUP 11 ;
+                                                  DIG 11 ;
                                                   CDR ;
-                                                  DIG 12 ;
+                                                  DIG 11 ;
                                                   DIG 7 ;
                                                   UPDATE 5 ;
                                                   SOME ;
@@ -1718,31 +1675,22 @@
                                                   UPDATE 1 ;
                                                   UPDATE 2 ;
                                                   UPDATE 1 ;
-                                                  SELF_ADDRESS ;
-                                                  DIG 4 ;
-                                                  CAR ;
-                                                  CDR ;
-                                                  CAR ;
-                                                  CAR ;
-                                                  CONTRACT unit ;
-                                                  IF_NONE
-                                                    { DIG 4 ; DROP ; PUSH nat 102 ; FAILWITH }
-                                                    { DIG 5 ; UNIT ; TRANSFER_TOKENS } ;
-                                                  DUP 5 ;
+                                                  DUP 3 ;
                                                   GET 7 ;
                                                   CAR ;
-                                                  DUP ;
+                                                  SELF_ADDRESS ;
+                                                  DUP 2 ;
                                                   CAR ;
                                                   GET 5 ;
                                                   IF_NONE
-                                                    { DIG 2 ; DIG 5 ; DROP 3 ; PUSH nat 109 ; FAILWITH }
-                                                    { DIG 6 ;
+                                                    { SWAP ; DIG 4 ; DROP 3 ; PUSH nat 109 ; FAILWITH }
+                                                    { DIG 5 ;
                                                       GET 5 ;
-                                                      DUP 3 ;
+                                                      DUP 4 ;
                                                       CAR ;
                                                       GET 8 ;
                                                       IF_NONE
-                                                        { SWAP ; DIG 2 ; DIG 4 ; DROP 4 ; PUSH nat 108 ; FAILWITH }
+                                                        { DROP 4 ; PUSH nat 108 ; FAILWITH }
                                                         { PUSH string "FA1.2 token" ;
                                                           DUP 2 ;
                                                           COMPARE ;
@@ -1752,9 +1700,9 @@
                                                                CONTRACT %transfer (pair (address %from) (address %to) (nat %value)) ;
                                                                IF_NONE { PUSH nat 101 ; FAILWITH } {} ;
                                                                PUSH mutez 0 ;
-                                                               DIG 3 ;
+                                                               DIG 4 ;
                                                                CDR ;
-                                                               DIG 5 ;
+                                                               DIG 4 ;
                                                                DIG 4 ;
                                                                PAIR 3 ;
                                                                TRANSFER_TOKENS }
@@ -1769,27 +1717,27 @@
                                                                     PUSH mutez 0 ;
                                                                     NIL (pair address (list (pair address nat nat))) ;
                                                                     NIL (pair address nat nat) ;
-                                                                    DUP 6 ;
+                                                                    DUP 7 ;
                                                                     CDR ;
-                                                                    DIG 6 ;
+                                                                    DIG 7 ;
                                                                     CAR ;
                                                                     CAR ;
-                                                                    DIG 8 ;
+                                                                    DIG 7 ;
                                                                     PAIR 3 ;
                                                                     CONS ;
                                                                     DIG 4 ;
                                                                     PAIR ;
                                                                     CONS ;
                                                                     TRANSFER_TOKENS }
-                                                                  { SWAP ; DIG 2 ; DIG 4 ; DROP 4 ; PUSH nat 108 ; FAILWITH } } } } ;
-                                                  DUP 3 ;
-                                                  DIG 3 ;
+                                                                  { DROP 4 ; PUSH nat 108 ; FAILWITH } } } } ;
+                                                  DUP 2 ;
+                                                  DIG 2 ;
                                                   CDR ;
                                                   DUP ;
                                                   CAR ;
                                                   DUP ;
                                                   CDR ;
-                                                  DIG 6 ;
+                                                  DIG 5 ;
                                                   UPDATE 1 ;
                                                   UPDATE 2 ;
                                                   UPDATE 1 ;
@@ -1797,11 +1745,9 @@
                                                   NIL operation ;
                                                   DIG 2 ;
                                                   CONS ;
-                                                  DIG 2 ;
-                                                  CONS ;
                                                   PAIR }
-                                                { DROP 7 ; PUSH nat 112 ; FAILWITH } }
-                                           { DROP 6 ; PUSH nat 103 ; FAILWITH } } } } }
+                                                { DROP 6 ; PUSH nat 112 ; FAILWITH } }
+                                           { DROP 5 ; PUSH nat 103 ; FAILWITH } } } } }
                        { DUP 2 ;
                          CAR ;
                          CAR ;
@@ -1905,47 +1851,69 @@
                          LT ;
                          IF {} { PUSH nat 118 ; FAILWITH } ;
                          SELF_ADDRESS ;
+                         PUSH mutez 0 ;
+                         PUSH mutez 0 ;
+                         PAIR ;
                          DUP 3 ;
+                         DUP 5 ;
+                         CAR ;
+                         CDR ;
+                         CAR ;
+                         CAR ;
+                         PAIR ;
+                         PAIR ;
+                         DUP 4 ;
                          CDR ;
                          CAR ;
                          CDR ;
                          CAR ;
                          DUP ;
-                         DUP 4 ;
+                         DUP 5 ;
                          GET ;
                          IF_NONE
-                           { DIG 4 ;
-                             DIG 5 ;
+                           { DIG 5 ;
+                             DIG 6 ;
                              DROP 2 ;
                              EMPTY_MAP string (pair (pair nat string (option address) nat (option string)) nat) ;
                              SWAP }
-                           { DUP 5 ;
+                           { DUP 6 ;
+                             CAR ;
+                             CAR ;
                              CDR ;
                              CDR ;
+                             DIG 3 ;
+                             PAIR ;
                              DUP 6 ;
+                             CDR ;
+                             CDR ;
+                             DUP 7 ;
                              CAR ;
                              CAR ;
                              CAR ;
                              CDR ;
                              PAIR ;
                              EMPTY_MAP string (pair (pair nat string (option address) nat (option string)) nat) ;
-                             DUP 3 ;
+                             DUP 4 ;
+                             PAIR ;
                              PAIR ;
                              PAIR ;
                              SWAP ;
                              ITER { SWAP ;
                                     UNPAIR ;
                                     UNPAIR ;
+                                    UNPAIR ;
                                     DIG 2 ;
                                     UNPAIR ;
                                     DIG 4 ;
                                     UNPAIR ;
-                                    DUP 3 ;
+                                    DIG 6 ;
+                                    UNPAIR ;
+                                    DUP 5 ;
                                     CDR ;
                                     DUP 2 ;
                                     GET ;
                                     IF_NONE
-                                      { DROP 2 ; PAIR ; DUG 2 }
+                                      { DROP 2 ; PAIR ; DUG 2 ; PAIR ; DIG 3 ; DIG 3 }
                                       { DUP ;
                                         GET 3 ;
                                         IF_LEFT
@@ -1962,38 +1930,45 @@
                                                        (pair nat nat nat nat)
                                                        (pair (pair string string) (pair int int) timestamp)) } ;
                                         IF_NONE
-                                          { DROP 3 ; PAIR ; DUG 2 }
+                                          { DROP 3 ; PAIR ; DUG 2 ; PAIR ; DIG 3 ; DIG 3 }
                                           { DUP 6 ;
-                                            DIG 2 ;
+                                            DIG 5 ;
+                                            PAIR ;
+                                            DUP 8 ;
+                                            DIG 3 ;
                                             GET 5 ;
                                             PAIR ;
-                                            DIG 7 ;
-                                            DIG 2 ;
+                                            DIG 9 ;
+                                            DIG 3 ;
+                                            PAIR ;
                                             PAIR ;
                                             PAIR ;
                                             DIG 2 ;
                                             ITER { SWAP ;
                                                    UNPAIR ;
                                                    UNPAIR ;
+                                                   UNPAIR ;
                                                    DIG 2 ;
                                                    UNPAIR ;
                                                    DIG 4 ;
                                                    UNPAIR ;
+                                                   DIG 6 ;
+                                                   UNPAIR ;
                                                    PUSH nat 0 ;
-                                                   DUP 4 ;
+                                                   DUP 6 ;
                                                    GET 7 ;
                                                    COMPARE ;
                                                    EQ ;
                                                    IF { PUSH bool False }
                                                       { PUSH nat 0 ;
-                                                        DUP 4 ;
+                                                        DUP 6 ;
                                                         GET 14 ;
                                                         COMPARE ;
                                                         EQ ;
                                                         IF { PUSH bool False }
                                                            { DUP ;
                                                              CDR ;
-                                                             DUP 6 ;
+                                                             DUP 8 ;
                                                              GET 3 ;
                                                              DUP 3 ;
                                                              CAR ;
@@ -2030,15 +2005,15 @@
                                                                      IF_LEFT
                                                                        { IF_LEFT { DROP ; PUSH bool True } { DROP ; PUSH bool True } }
                                                                        { DROP ; PUSH bool True } } } } } ;
-                                                   IF { DUP 5 ;
+                                                   IF { DUP 7 ;
                                                         GET 6 ;
                                                         CAR ;
-                                                        DUP 5 ;
+                                                        DUP 7 ;
                                                         DUP 2 ;
                                                         CAR ;
                                                         GET ;
                                                         IF_NONE { PUSH nat 111 ; FAILWITH } {} ;
-                                                        DUP 6 ;
+                                                        DUP 8 ;
                                                         DIG 2 ;
                                                         CDR ;
                                                         GET ;
@@ -2047,7 +2022,7 @@
                                                         CAR ;
                                                         IF_LEFT
                                                           { DROP ;
-                                                            DUP 6 ;
+                                                            DUP 8 ;
                                                             GET 5 ;
                                                             DUP ;
                                                             GET 5 ;
@@ -2088,7 +2063,7 @@
                                                             CAR ;
                                                             MUL ;
                                                             PAIR ;
-                                                            DUP 7 ;
+                                                            DUP 9 ;
                                                             GET 6 ;
                                                             GET 3 ;
                                                             DUP ;
@@ -2131,7 +2106,7 @@
                                                             PUSH nat 0 ;
                                                             PUSH nat 10 ;
                                                             PAIR ;
-                                                            DUP 20 ;
+                                                            DUP 23 ;
                                                             SWAP ;
                                                             EXEC ;
                                                             DIG 2 ;
@@ -2149,7 +2124,7 @@
                                                             CDR ;
                                                             COMPARE ;
                                                             GT ;
-                                                            IF { DIG 6 ; SWAP ; PAIR ; DUP 15 ; SWAP ; EXEC } { DROP ; DIG 5 } ;
+                                                            IF { DIG 8 ; SWAP ; PAIR ; DUP 18 ; SWAP ; EXEC } { DROP ; DIG 7 } ;
                                                             PUSH int 1 ;
                                                             PUSH int 0 ;
                                                             PAIR ;
@@ -2178,7 +2153,7 @@
                                                                  PUSH nat 0 ;
                                                                  PUSH nat 10 ;
                                                                  PAIR ;
-                                                                 DUP 18 ;
+                                                                 DUP 21 ;
                                                                  SWAP ;
                                                                  EXEC ;
                                                                  DIG 2 ;
@@ -2192,12 +2167,12 @@
                                                                  DIG 2 ;
                                                                  PAIR ;
                                                                  PAIR ;
-                                                                 DUP 13 ;
+                                                                 DUP 16 ;
                                                                  SWAP ;
                                                                  EXEC }
                                                                { SWAP ; DIG 2 ; DROP 2 } }
                                                           { DROP ;
-                                                            DUP 6 ;
+                                                            DUP 8 ;
                                                             GET 5 ;
                                                             DUP ;
                                                             CAR ;
@@ -2238,7 +2213,7 @@
                                                             CAR ;
                                                             MUL ;
                                                             PAIR ;
-                                                            DUP 7 ;
+                                                            DUP 9 ;
                                                             GET 6 ;
                                                             GET 3 ;
                                                             DUP ;
@@ -2281,7 +2256,7 @@
                                                             PUSH nat 0 ;
                                                             PUSH nat 10 ;
                                                             PAIR ;
-                                                            DUP 20 ;
+                                                            DUP 23 ;
                                                             SWAP ;
                                                             EXEC ;
                                                             DIG 2 ;
@@ -2299,7 +2274,7 @@
                                                             CDR ;
                                                             COMPARE ;
                                                             GT ;
-                                                            IF { DIG 6 ; SWAP ; PAIR ; DUP 15 ; SWAP ; EXEC } { DROP ; DIG 5 } ;
+                                                            IF { DIG 8 ; SWAP ; PAIR ; DUP 18 ; SWAP ; EXEC } { DROP ; DIG 7 } ;
                                                             PUSH int 1 ;
                                                             PUSH int 0 ;
                                                             PAIR ;
@@ -2328,7 +2303,7 @@
                                                                  PUSH nat 0 ;
                                                                  PUSH nat 10 ;
                                                                  PAIR ;
-                                                                 DUP 18 ;
+                                                                 DUP 21 ;
                                                                  SWAP ;
                                                                  EXEC ;
                                                                  DIG 2 ;
@@ -2342,66 +2317,106 @@
                                                                  DIG 2 ;
                                                                  PAIR ;
                                                                  PAIR ;
-                                                                 DUP 13 ;
+                                                                 DUP 16 ;
                                                                  SWAP ;
                                                                  EXEC }
-                                                               { SWAP ; DIG 2 ; DROP 2 } } }
-                                                      { DUP 5 ;
+                                                               { SWAP ; DIG 2 ; DROP 2 } } ;
+                                                        DUP 3 ;
+                                                        DUP 3 ;
+                                                        CDR ;
+                                                        CAR ;
+                                                        ADD ;
+                                                        DUP 3 ;
+                                                        DIG 3 ;
+                                                        CDR ;
+                                                        DIG 2 ;
+                                                        UPDATE 1 ;
+                                                        UPDATE 2 ;
+                                                        SWAP }
+                                                      { DUP 7 ;
                                                         GET 6 ;
                                                         CAR ;
                                                         SWAP ;
                                                         CAR ;
                                                         IF_LEFT
                                                           { DROP ;
-                                                            DUP 4 ;
+                                                            DUP 6 ;
                                                             SWAP ;
                                                             CAR ;
                                                             GET ;
                                                             IF_NONE { PUSH nat 111 ; FAILWITH } {} }
                                                           { DROP ;
-                                                            DUP 4 ;
+                                                            DUP 6 ;
                                                             SWAP ;
                                                             CDR ;
                                                             GET ;
                                                             IF_NONE { PUSH nat 111 ; FAILWITH } {} } ;
-                                                        DIG 5 ;
-                                                        DUG 2 ;
+                                                        DUP 4 ;
+                                                        DUP 4 ;
+                                                        CDR ;
+                                                        CDR ;
+                                                        ADD ;
+                                                        DUP 4 ;
+                                                        DIG 4 ;
+                                                        CDR ;
+                                                        DIG 2 ;
+                                                        UPDATE 2 ;
+                                                        UPDATE 2 ;
+                                                        DIG 7 ;
+                                                        DIG 3 ;
+                                                        DIG 3 ;
                                                         PAIR ;
                                                         PAIR ;
-                                                        DUP 13 ;
+                                                        DUP 16 ;
                                                         SWAP ;
                                                         EXEC } ;
                                                    DUG 2 ;
                                                    PAIR ;
-                                                   SWAP ;
+                                                   DIG 3 ;
+                                                   DIG 3 ;
+                                                   PAIR ;
                                                    DIG 2 ;
+                                                   DIG 3 ;
+                                                   PAIR ;
                                                    PAIR ;
                                                    PAIR } ;
+                                            UNPAIR ;
                                             CAR ;
                                             CDR ;
-                                            DIG 3 ;
-                                            DIG 3 ;
-                                            PAIR ;
                                             SWAP ;
+                                            CAR ;
                                             DIG 3 ;
-                                            DIG 3 ;
+                                            SWAP ;
+                                            PAIR ;
+                                            DIG 4 ;
+                                            DIG 4 ;
+                                            PAIR ;
+                                            DIG 2 ;
+                                            DIG 4 ;
+                                            DIG 4 ;
                                             NONE (map (pair (or unit unit) (or (or unit unit) unit)) nat) ;
                                             SWAP ;
                                             UPDATE } } ;
+                                    PAIR ;
                                     PAIR ;
                                     PAIR } ;
                              DIG 5 ;
                              DIG 6 ;
                              DROP 2 ;
+                             UNPAIR ;
                              CAR ;
                              UNPAIR ;
-                             SWAP ;
-                             DUG 2 ;
+                             DIG 2 ;
+                             CAR ;
+                             DIG 2 ;
+                             DIG 3 ;
+                             DIG 3 ;
                              SOME ;
-                             DUP 5 ;
+                             DUP 6 ;
                              UPDATE } ;
-                         NIL operation ;
                          DIG 2 ;
+                         NIL operation ;
+                         DIG 3 ;
                          ITER { CDR ;
                                 DUP ;
                                 CAR ;
@@ -2423,8 +2438,8 @@
                                              PUSH mutez 0 ;
                                              DIG 2 ;
                                              CDR ;
-                                             DUP 7 ;
-                                             DUP 7 ;
+                                             DUP 8 ;
+                                             DUP 8 ;
                                              PAIR 3 ;
                                              TRANSFER_TOKENS }
                                            { PUSH string "FA2 token" ;
@@ -2442,31 +2457,65 @@
                                                   DIG 5 ;
                                                   CAR ;
                                                   CAR ;
-                                                  DUP 10 ;
+                                                  DUP 11 ;
                                                   PAIR 3 ;
                                                   CONS ;
-                                                  DUP 7 ;
+                                                  DUP 8 ;
                                                   PAIR ;
                                                   CONS ;
                                                   TRANSFER_TOKENS }
                                                 { DROP 2 ; PUSH nat 108 ; FAILWITH } } } } ;
                                 CONS } ;
-                         DIG 2 ;
                          DIG 3 ;
+                         DIG 4 ;
                          DROP 2 ;
+                         PUSH mutez 0 ;
                          DUP 3 ;
-                         DIG 3 ;
+                         CDR ;
+                         CAR ;
+                         COMPARE ;
+                         GT ;
+                         IF { DUP 2 ;
+                              CAR ;
+                              CAR ;
+                              CONTRACT unit ;
+                              IF_NONE
+                                { PUSH nat 102 ; FAILWITH }
+                                { DUP 3 ; CDR ; CAR ; UNIT ; TRANSFER_TOKENS } ;
+                              SOME }
+                            { NONE operation } ;
+                         PUSH mutez 0 ;
+                         DUP 4 ;
+                         CDR ;
+                         CDR ;
+                         COMPARE ;
+                         GT ;
+                         IF { DUP 3 ;
+                              CAR ;
+                              CDR ;
+                              CONTRACT unit ;
+                              IF_NONE
+                                { DIG 2 ; DROP ; PUSH nat 102 ; FAILWITH }
+                                { DIG 3 ; CDR ; CDR ; UNIT ; TRANSFER_TOKENS } ;
+                              SOME }
+                            { DIG 2 ; DROP ; NONE operation } ;
+                         DUP 5 ;
+                         DIG 5 ;
                          CDR ;
                          DUP ;
                          CAR ;
                          DUP ;
                          CDR ;
-                         DIG 5 ;
+                         DIG 7 ;
                          UPDATE 1 ;
                          UPDATE 2 ;
                          UPDATE 1 ;
                          UPDATE 2 ;
-                         SWAP } ;
+                         DIG 2 ;
+                         IF_NONE
+                           { SWAP ;
+                             IF_NONE { SWAP ; DROP ; NIL operation } { DIG 2 ; SWAP ; CONS } }
+                           { DIG 2 ; IF_NONE { DIG 2 } { DIG 3 ; SWAP ; CONS } ; SWAP ; CONS } } ;
                      PAIR } }
                { DIG 3 ;
                  DROP ;
@@ -2984,12 +3033,9 @@
                          COMPARE ;
                          LT ;
                          IF {} { PUSH nat 120 ; FAILWITH } ;
-                         DUP 5 ;
-                         CDR ;
-                         CDR ;
-                         DUP 4 ;
+                         DUP 3 ;
                          CAR ;
-                         DIG 4 ;
+                         DIG 3 ;
                          GET 7 ;
                          DUP ;
                          DUP 3 ;
@@ -3005,10 +3051,10 @@
                               SUB ;
                               PUSH int 10 ;
                               PAIR ;
-                              DUP 8 ;
+                              DUP 7 ;
                               SWAP ;
                               EXEC ;
-                              DIG 4 ;
+                              DIG 3 ;
                               MUL ;
                               ISNAT ;
                               IF_NONE { PUSH nat 119 ; FAILWITH } {} ;
@@ -3019,11 +3065,11 @@
                               INT ;
                               PUSH int 10 ;
                               PAIR ;
-                              DUP 8 ;
+                              DUP 7 ;
                               SWAP ;
                               EXEC ;
                               SWAP }
-                            { INT ; PUSH int 10 ; PAIR ; DUP 8 ; SWAP ; EXEC ; DIG 4 } ;
+                            { INT ; PUSH int 10 ; PAIR ; DUP 7 ; SWAP ; EXEC ; DIG 3 } ;
                          INT ;
                          PUSH int 1 ;
                          DIG 2 ;
@@ -3042,7 +3088,7 @@
                          CAR ;
                          MUL ;
                          PAIR ;
-                         DIG 3 ;
+                         DIG 2 ;
                          SWAP ;
                          DUP 3 ;
                          CDR ;
@@ -3053,15 +3099,17 @@
                          GET 3 ;
                          PAIR ;
                          PAIR 3 ;
-                         DUP ;
-                         CAR ;
                          DUP 3 ;
+                         CDR ;
+                         CDR ;
+                         DUP 2 ;
+                         CAR ;
+                         DUP 2 ;
                          DUP 2 ;
                          CAR ;
                          GET ;
                          IF_NONE { PUSH nat 111 ; FAILWITH } {} ;
-                         DIG 3 ;
-                         DIG 2 ;
+                         DUG 2 ;
                          CDR ;
                          GET ;
                          IF_NONE { PUSH nat 111 ; FAILWITH } {} ;
@@ -3150,24 +3198,19 @@
                          CAR ;
                          UNIT ;
                          LEFT unit ;
-                         PAIR ;
+                         IF_LEFT { DROP } { DROP ; DUP ; CAR ; SWAP ; CDR ; PAIR } ;
                          NOW ;
                          DUP 3 ;
                          CAR ;
                          CAR ;
                          CAR ;
                          CDR ;
-                         DIG 2 ;
-                         UNPAIR ;
-                         IF_LEFT { DROP } { DROP ; DUP ; CAR ; SWAP ; CDR ; PAIR } ;
+                         CDR ;
                          DUP 4 ;
+                         CAR ;
                          CAR ;
                          CAR ;
                          CDR ;
-                         CAR ;
-                         DUP 3 ;
-                         CDR ;
-                         DUP 4 ;
                          CAR ;
                          DUP 4 ;
                          UNPAIR ;
@@ -3181,7 +3224,13 @@
                          IF_NONE { PUSH nat 0 } {} ;
                          GET ;
                          IF_NONE
-                           { DROP 2 ;
+                           { SWAP ;
+                             DROP ;
+                             DUP 2 ;
+                             CAR ;
+                             CAR ;
+                             CAR ;
+                             CDR ;
                              NONE (pair nat
                                         (or (or (pair (pair timestamp
                                                             (pair (pair nat nat nat)
@@ -3193,20 +3242,31 @@
                                             timestamp)
                                         (pair nat nat nat nat nat nat nat nat)
                                         (pair string string)) }
-                           { DUP ;
+                           { DUP 4 ;
+                             CAR ;
+                             CAR ;
+                             CAR ;
+                             CDR ;
+                             DUP 5 ;
+                             CAR ;
+                             CAR ;
+                             CDR ;
+                             CAR ;
+                             DUP 3 ;
                              GET 3 ;
                              IF_LEFT
-                               { DIG 2 ;
+                               { SWAP ;
                                  DROP ;
                                  IF_LEFT
-                                   { DROP 2 ;
+                                   { DIG 2 ;
+                                     DROP 2 ;
                                      PUSH nat 0 ;
-                                     DUP 3 ;
+                                     DUP 2 ;
                                      CAR ;
                                      ITER { CDR ; DUP 2 ; DUP 2 ; COMPARE ; GT ; IF { SWAP ; DROP } { DROP } } ;
                                      PUSH nat 1 ;
                                      ADD ;
-                                     SWAP ;
+                                     DIG 3 ;
                                      PUSH nat 0 ;
                                      PUSH nat 0 ;
                                      PUSH nat 0 ;
@@ -3252,25 +3312,25 @@
                                         { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                                      UPDATE ;
                                      UPDATE 1 }
-                                   { DIG 2 ; DROP 2 ; SWAP } }
-                               { DIG 3 ;
+                                   { DIG 4 ; DROP 2 } }
+                               { DIG 5 ;
                                  DROP ;
-                                 DUP 3 ;
+                                 DUP 2 ;
                                  INT ;
                                  ADD ;
                                  DUP 5 ;
                                  COMPARE ;
                                  GE ;
-                                 IF { DUP ;
+                                 IF { DUP 3 ;
                                       GET 3 ;
                                       IF_LEFT
                                         { SWAP ;
-                                          DIG 2 ;
+                                          DIG 3 ;
                                           DROP 2 ;
                                           IF_LEFT
                                             { DROP ; PUSH nat 105 ; FAILWITH }
                                             { DROP ; PUSH nat 105 ; FAILWITH } }
-                                        { DIG 2 ;
+                                        { SWAP ;
                                           INT ;
                                           DUP 2 ;
                                           ADD ;
@@ -3283,6 +3343,8 @@
                                                               (pair (pair string string) (pair int int) timestamp)))
                                                   (pair (pair string string) (pair int int) timestamp)) ;
                                           LEFT timestamp ;
+                                          DIG 2 ;
+                                          SWAP ;
                                           UPDATE 3 } ;
                                       DUP 2 ;
                                       DUP 3 ;
@@ -3309,7 +3371,7 @@
                                          { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                                       UPDATE ;
                                       UPDATE 1 }
-                                    { SWAP ; DROP ; SWAP } } ;
+                                    { DROP } } ;
                              SWAP ;
                              SOME } ;
                          IF_NONE


### PR DESCRIPTION
- Removed burn from deposit
- At point of redemption, the amount of fees that should be burned or refunded is calculated with the token payouts and executed along with the token transfer operations