### PR TITLE
Remove Batches that have no holdings

### DIFF
--- a/batcher/batcher-ghostnet.tz
+++ b/batcher/batcher-ghostnet.tz
@@ -2982,6 +2982,7 @@
                                             DUP 5 ;
                                             CAR ;
                                             MEM ;
+                                            NOT ;
                                             IF { DUP 6 ;
                                                  DIG 6 ;
                                                  CDR ;

--- a/batcher/batcher-ghostnet.tz
+++ b/batcher/batcher-ghostnet.tz
@@ -140,40 +140,7 @@
                    (option %address address)
                    (nat %decimals)
                    (option %standard string)))) ;
-  code { LAMBDA
-           (pair nat nat)
-           nat
-           { UNPAIR ;
-             PUSH nat 1 ;
-             DUG 2 ;
-             PAIR ;
-             PAIR ;
-             LEFT nat ;
-             LOOP_LEFT
-               { UNPAIR ;
-                 UNPAIR ;
-                 PUSH nat 0 ;
-                 DUP 3 ;
-                 COMPARE ;
-                 EQ ;
-                 IF { DROP 2 ; RIGHT (pair (pair nat nat) nat) }
-                    { PUSH nat 1 ;
-                      PUSH nat 1 ;
-                      DUP 4 ;
-                      AND ;
-                      COMPARE ;
-                      EQ ;
-                      IF { DUP ; DIG 3 ; MUL } { DIG 2 } ;
-                      PUSH nat 1 ;
-                      DIG 3 ;
-                      LSR ;
-                      DUP 3 ;
-                      DIG 3 ;
-                      MUL ;
-                      PAIR ;
-                      PAIR ;
-                      LEFT nat } } } ;
-         PUSH int 1 ;
+  code { PUSH int 1 ;
          PUSH int 10000 ;
          PAIR ;
          PUSH int 1 ;
@@ -244,13 +211,12 @@
                     { PUSH int 1 ; DIG 2 ; SUB ; DUP 3 ; DIG 2 ; MUL ; PAIR ; LEFT int } } ;
              SWAP ;
              DROP } ;
-         DIG 4 ;
+         DIG 3 ;
          UNPAIR ;
          IF_LEFT
            { DIG 2 ;
              DIG 4 ;
-             DIG 5 ;
-             DROP 3 ;
+             DROP 2 ;
              IF_LEFT
                { IF_LEFT
                    { DIG 2 ;
@@ -772,22 +738,21 @@
                          SENDER ;
                          DUP 2 ;
                          UNPAIR ;
-                         DUP 2 ;
-                         DUP 2 ;
-                         COMPARE ;
-                         GT ;
-                         IF { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
-                            { PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
-                         DUP 4 ;
+                         DUP 5 ;
                          CDR ;
                          CAR ;
                          CDR ;
                          CDR ;
-                         DUP 2 ;
+                         DUP 3 ;
+                         DUP 3 ;
+                         COMPARE ;
+                         GT ;
+                         IF { DIG 2 ; PUSH string "/" ; CONCAT ; DIG 2 ; CONCAT }
+                            { SWAP ; PUSH string "/" ; CONCAT ; DIG 2 ; CONCAT } ;
                          GET ;
                          IF_NONE
-                           { DROP 5 ; PUSH nat 117 ; FAILWITH }
-                           { DUP 5 ;
+                           { DROP 4 ; PUSH nat 117 ; FAILWITH }
+                           { DUP 4 ;
                              CDR ;
                              CDR ;
                              DUP 2 ;
@@ -815,48 +780,264 @@
                              PAIR ;
                              PAIR ;
                              PAIR 5 ;
+                             NOW ;
                              DUP 5 ;
+                             CAR ;
+                             CAR ;
+                             CDR ;
+                             CAR ;
+                             DUP 6 ;
+                             CAR ;
+                             CAR ;
+                             CAR ;
+                             CDR ;
+                             CDR ;
+                             DUP 7 ;
                              CAR ;
                              CAR ;
                              CAR ;
                              CDR ;
                              CAR ;
-                             DIG 2 ;
+                             DUP 7 ;
+                             UNPAIR ;
+                             DUP ;
+                             DUP 3 ;
+                             COMPARE ;
+                             GT ;
+                             IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
+                                { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                              GET ;
-                             IF_NONE { PUSH nat 103 ; FAILWITH } {} ;
+                             IF_NONE { PUSH nat 0 } {} ;
+                             GET ;
+                             IF_NONE
+                               { DROP ;
+                                 DUP 5 ;
+                                 CAR ;
+                                 CAR ;
+                                 CAR ;
+                                 CDR ;
+                                 PUSH nat 0 ;
+                                 DUP 2 ;
+                                 CAR ;
+                                 ITER { CDR ; DUP 2 ; DUP 2 ; COMPARE ; GT ; IF { SWAP ; DROP } { DROP } } ;
+                                 PUSH nat 1 ;
+                                 ADD ;
+                                 DIG 5 ;
+                                 PUSH nat 0 ;
+                                 PUSH nat 0 ;
+                                 PUSH nat 0 ;
+                                 PUSH nat 0 ;
+                                 PUSH nat 0 ;
+                                 PUSH nat 0 ;
+                                 PUSH nat 0 ;
+                                 PUSH nat 0 ;
+                                 PAIR 8 ;
+                                 DIG 4 ;
+                                 RIGHT
+                                   (or (pair (pair timestamp
+                                                   (pair (pair nat nat nat)
+                                                         (or (or unit unit) unit)
+                                                         (pair nat nat nat nat)
+                                                         (pair (pair string string) (pair int int) timestamp)))
+                                             (pair (pair string string) (pair int int) timestamp))
+                                       (pair timestamp timestamp)) ;
+                                 DIG 3 ;
+                                 PAIR 4 ;
+                                 DUP 2 ;
+                                 DUP 3 ;
+                                 CDR ;
+                                 DUP 3 ;
+                                 SOME ;
+                                 DUP 4 ;
+                                 CAR ;
+                                 UPDATE ;
+                                 UPDATE 2 ;
+                                 DIG 2 ;
+                                 CAR ;
+                                 DUP 3 ;
+                                 CAR ;
+                                 SOME ;
+                                 DUP 4 ;
+                                 GET 6 ;
+                                 UNPAIR ;
+                                 DUP ;
+                                 DUP 3 ;
+                                 COMPARE ;
+                                 GT ;
+                                 IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
+                                    { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
+                                 UPDATE ;
+                                 UPDATE 1 }
+                               { DUP ;
+                                 GET 3 ;
+                                 IF_LEFT
+                                   { DIG 2 ;
+                                     DROP ;
+                                     IF_LEFT
+                                       { DROP 2 ;
+                                         DUP 5 ;
+                                         CAR ;
+                                         CAR ;
+                                         CAR ;
+                                         CDR ;
+                                         PUSH nat 0 ;
+                                         DUP 2 ;
+                                         CAR ;
+                                         ITER { CDR ; DUP 2 ; DUP 2 ; COMPARE ; GT ; IF { SWAP ; DROP } { DROP } } ;
+                                         PUSH nat 1 ;
+                                         ADD ;
+                                         DIG 5 ;
+                                         PUSH nat 0 ;
+                                         PUSH nat 0 ;
+                                         PUSH nat 0 ;
+                                         PUSH nat 0 ;
+                                         PUSH nat 0 ;
+                                         PUSH nat 0 ;
+                                         PUSH nat 0 ;
+                                         PUSH nat 0 ;
+                                         PAIR 8 ;
+                                         DIG 4 ;
+                                         RIGHT
+                                           (or (pair (pair timestamp
+                                                           (pair (pair nat nat nat)
+                                                                 (or (or unit unit) unit)
+                                                                 (pair nat nat nat nat)
+                                                                 (pair (pair string string) (pair int int) timestamp)))
+                                                     (pair (pair string string) (pair int int) timestamp))
+                                               (pair timestamp timestamp)) ;
+                                         DIG 3 ;
+                                         PAIR 4 ;
+                                         DUP 2 ;
+                                         DUP 3 ;
+                                         CDR ;
+                                         DUP 3 ;
+                                         SOME ;
+                                         DUP 4 ;
+                                         CAR ;
+                                         UPDATE ;
+                                         UPDATE 2 ;
+                                         DIG 2 ;
+                                         CAR ;
+                                         DUP 3 ;
+                                         CAR ;
+                                         SOME ;
+                                         DUP 4 ;
+                                         GET 6 ;
+                                         UNPAIR ;
+                                         DUP ;
+                                         DUP 3 ;
+                                         COMPARE ;
+                                         GT ;
+                                         IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
+                                            { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
+                                         UPDATE ;
+                                         UPDATE 1 }
+                                       { DIG 2 ; DIG 5 ; DROP 3 ; DUP 4 ; CAR ; CAR ; CAR ; CDR } }
+                                   { DIG 6 ;
+                                     DROP ;
+                                     DUP 3 ;
+                                     INT ;
+                                     ADD ;
+                                     DIG 3 ;
+                                     COMPARE ;
+                                     GE ;
+                                     IF { DUP ;
+                                          GET 3 ;
+                                          IF_LEFT
+                                            { SWAP ;
+                                              DIG 2 ;
+                                              DROP 2 ;
+                                              IF_LEFT
+                                                { DROP ; PUSH nat 105 ; FAILWITH }
+                                                { DROP ; PUSH nat 105 ; FAILWITH } }
+                                            { DIG 2 ;
+                                              INT ;
+                                              DUP 2 ;
+                                              ADD ;
+                                              PAIR ;
+                                              RIGHT
+                                                (pair (pair timestamp
+                                                            (pair (pair nat nat nat)
+                                                                  (or (or unit unit) unit)
+                                                                  (pair nat nat nat nat)
+                                                                  (pair (pair string string) (pair int int) timestamp)))
+                                                      (pair (pair string string) (pair int int) timestamp)) ;
+                                              LEFT timestamp ;
+                                              UPDATE 3 } ;
+                                          DUP 4 ;
+                                          CAR ;
+                                          CAR ;
+                                          CAR ;
+                                          CDR ;
+                                          DUP ;
+                                          DUP 2 ;
+                                          CDR ;
+                                          DUP 4 ;
+                                          SOME ;
+                                          DUP 5 ;
+                                          CAR ;
+                                          UPDATE ;
+                                          UPDATE 2 ;
+                                          SWAP ;
+                                          CAR ;
+                                          DUP 3 ;
+                                          CAR ;
+                                          SOME ;
+                                          DUP 4 ;
+                                          GET 6 ;
+                                          UNPAIR ;
+                                          DUP ;
+                                          DUP 3 ;
+                                          COMPARE ;
+                                          GT ;
+                                          IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
+                                             { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
+                                          UPDATE ;
+                                          UPDATE 1 }
+                                        { SWAP ; DROP ; DUP 4 ; CAR ; CAR ; CAR ; CDR } } } ;
+                             SWAP ;
+                             DUP ;
+                             GET 3 ;
+                             IF_LEFT
+                               { IF_LEFT { DROP ; PUSH bool False } { DROP ; PUSH bool False } }
+                               { DROP ; PUSH bool True } ;
+                             NOT ;
+                             IF { PUSH nat 140 ; FAILWITH } {} ;
                              DUP 5 ;
                              CDR ;
                              CAR ;
                              CDR ;
                              CAR ;
-                             DUP 4 ;
+                             DUP 5 ;
                              GET ;
                              IF_NONE
                                { DROP 6 ; PUSH nat 139 ; FAILWITH }
-                               { DUP ;
-                                 DUP 3 ;
+                               { DUP 2 ;
+                                 CAR ;
+                                 DUP 2 ;
+                                 DUP 2 ;
                                  GET ;
                                  IF_NONE
-                                   { DIG 5 ; DROP 2 ; PUSH nat 139 ; FAILWITH }
-                                   { DUP 7 ;
-                                     DUP 8 ;
+                                   { SWAP ; DIG 6 ; DROP 3 ; PUSH nat 139 ; FAILWITH }
+                                   { DUP 8 ;
+                                     DUP 9 ;
                                      CDR ;
                                      DUP ;
                                      CAR ;
                                      DUP ;
                                      CDR ;
-                                     DIG 10 ;
+                                     DIG 11 ;
                                      CDR ;
                                      CAR ;
                                      CDR ;
                                      CAR ;
-                                     DIG 6 ;
-                                     DUP 8 ;
+                                     DIG 7 ;
+                                     DIG 7 ;
                                      NONE (map (pair (or unit unit) (or (or unit unit) unit)) nat) ;
                                      SWAP ;
                                      UPDATE ;
                                      SOME ;
-                                     DUP 10 ;
+                                     DUP 11 ;
                                      UPDATE ;
                                      UPDATE 1 ;
                                      UPDATE 2 ;
@@ -865,207 +1046,9 @@
                                      SWAP ;
                                      PAIR } ;
                                  UNPAIR ;
-                                 NOW ;
                                  DUP 3 ;
-                                 CAR ;
-                                 CAR ;
-                                 CAR ;
-                                 CDR ;
-                                 DUP 4 ;
-                                 CAR ;
-                                 CAR ;
-                                 CDR ;
-                                 CAR ;
-                                 DUP 2 ;
-                                 CDR ;
-                                 DUP 3 ;
-                                 CAR ;
-                                 DUP 11 ;
-                                 UNPAIR ;
-                                 DUP ;
-                                 DUP 3 ;
-                                 COMPARE ;
-                                 GT ;
-                                 IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
-                                    { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
-                                 GET ;
-                                 IF_NONE { PUSH nat 0 } {} ;
-                                 GET ;
-                                 IF_NONE
-                                   { DROP ;
-                                     PUSH nat 0 ;
-                                     DUP 2 ;
-                                     CAR ;
-                                     ITER { CDR ; DUP 2 ; DUP 2 ; COMPARE ; GT ; IF { SWAP ; DROP } { DROP } } ;
-                                     PUSH nat 1 ;
-                                     ADD ;
-                                     DIG 8 ;
-                                     PUSH nat 0 ;
-                                     PUSH nat 0 ;
-                                     PUSH nat 0 ;
-                                     PUSH nat 0 ;
-                                     PUSH nat 0 ;
-                                     PUSH nat 0 ;
-                                     PUSH nat 0 ;
-                                     PUSH nat 0 ;
-                                     PAIR 8 ;
-                                     DIG 4 ;
-                                     RIGHT
-                                       (or (pair (pair timestamp
-                                                       (pair (pair nat nat nat)
-                                                             (or (or unit unit) unit)
-                                                             (pair nat nat nat nat)
-                                                             (pair (pair string string) (pair int int) timestamp)))
-                                                 (pair (pair string string) (pair int int) timestamp))
-                                           (pair timestamp timestamp)) ;
-                                     DIG 3 ;
-                                     PAIR 4 ;
-                                     DUP 2 ;
-                                     DUP 3 ;
-                                     CDR ;
-                                     DUP 3 ;
-                                     SOME ;
-                                     DUP 4 ;
-                                     CAR ;
-                                     UPDATE ;
-                                     UPDATE 2 ;
-                                     DIG 2 ;
-                                     CAR ;
-                                     DUP 3 ;
-                                     CAR ;
-                                     SOME ;
-                                     DUP 4 ;
-                                     GET 6 ;
-                                     UNPAIR ;
-                                     DUP ;
-                                     DUP 3 ;
-                                     COMPARE ;
-                                     GT ;
-                                     IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
-                                        { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
-                                     UPDATE ;
-                                     UPDATE 1 }
-                                   { DUP ;
-                                     GET 3 ;
-                                     IF_LEFT
-                                       { DIG 2 ;
-                                         DROP ;
-                                         IF_LEFT
-                                           { DROP 2 ;
-                                             PUSH nat 0 ;
-                                             DUP 2 ;
-                                             CAR ;
-                                             ITER { CDR ; DUP 2 ; DUP 2 ; COMPARE ; GT ; IF { SWAP ; DROP } { DROP } } ;
-                                             PUSH nat 1 ;
-                                             ADD ;
-                                             DIG 8 ;
-                                             PUSH nat 0 ;
-                                             PUSH nat 0 ;
-                                             PUSH nat 0 ;
-                                             PUSH nat 0 ;
-                                             PUSH nat 0 ;
-                                             PUSH nat 0 ;
-                                             PUSH nat 0 ;
-                                             PUSH nat 0 ;
-                                             PAIR 8 ;
-                                             DIG 4 ;
-                                             RIGHT
-                                               (or (pair (pair timestamp
-                                                               (pair (pair nat nat nat)
-                                                                     (or (or unit unit) unit)
-                                                                     (pair nat nat nat nat)
-                                                                     (pair (pair string string) (pair int int) timestamp)))
-                                                         (pair (pair string string) (pair int int) timestamp))
-                                                   (pair timestamp timestamp)) ;
-                                             DIG 3 ;
-                                             PAIR 4 ;
-                                             DUP 2 ;
-                                             DUP 3 ;
-                                             CDR ;
-                                             DUP 3 ;
-                                             SOME ;
-                                             DUP 4 ;
-                                             CAR ;
-                                             UPDATE ;
-                                             UPDATE 2 ;
-                                             DIG 2 ;
-                                             CAR ;
-                                             DUP 3 ;
-                                             CAR ;
-                                             SOME ;
-                                             DUP 4 ;
-                                             GET 6 ;
-                                             UNPAIR ;
-                                             DUP ;
-                                             DUP 3 ;
-                                             COMPARE ;
-                                             GT ;
-                                             IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
-                                                { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
-                                             UPDATE ;
-                                             UPDATE 1 }
-                                           { DIG 3 ; DIG 9 ; DROP 3 ; SWAP } }
-                                       { DIG 10 ;
-                                         DROP ;
-                                         DUP 3 ;
-                                         INT ;
-                                         ADD ;
-                                         DIG 4 ;
-                                         COMPARE ;
-                                         GE ;
-                                         IF { DUP ;
-                                              GET 3 ;
-                                              IF_LEFT
-                                                { SWAP ;
-                                                  DIG 2 ;
-                                                  DROP 2 ;
-                                                  IF_LEFT
-                                                    { DROP ; PUSH nat 105 ; FAILWITH }
-                                                    { DROP ; PUSH nat 105 ; FAILWITH } }
-                                                { DIG 2 ;
-                                                  INT ;
-                                                  DUP 2 ;
-                                                  ADD ;
-                                                  PAIR ;
-                                                  RIGHT
-                                                    (pair (pair timestamp
-                                                                (pair (pair nat nat nat)
-                                                                      (or (or unit unit) unit)
-                                                                      (pair nat nat nat nat)
-                                                                      (pair (pair string string) (pair int int) timestamp)))
-                                                          (pair (pair string string) (pair int int) timestamp)) ;
-                                                  LEFT timestamp ;
-                                                  UPDATE 3 } ;
-                                              DUP 2 ;
-                                              DUP 3 ;
-                                              CDR ;
-                                              DUP 3 ;
-                                              SOME ;
-                                              DUP 4 ;
-                                              CAR ;
-                                              UPDATE ;
-                                              UPDATE 2 ;
-                                              DIG 2 ;
-                                              CAR ;
-                                              DUP 3 ;
-                                              CAR ;
-                                              SOME ;
-                                              DUP 4 ;
-                                              GET 6 ;
-                                              UNPAIR ;
-                                              DUP ;
-                                              DUP 3 ;
-                                              COMPARE ;
-                                              GT ;
-                                              IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
-                                                 { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
-                                              UPDATE ;
-                                              UPDATE 1 }
-                                            { SWAP ; DROP ; SWAP } } } ;
-                                 SWAP ;
-                                 DUP ;
                                  GET 5 ;
-                                 DUP 4 ;
+                                 DUP 2 ;
                                  ITER { UNPAIR ;
                                         UNPAIR ;
                                         IF_LEFT
@@ -1147,8 +1130,11 @@
                                                 UPDATE 13 ;
                                                 SWAP ;
                                                 UPDATE 14 } } } ;
-                                 DUP 5 ;
-                                 DIG 5 ;
+                                 DIG 3 ;
+                                 SWAP ;
+                                 UPDATE 5 ;
+                                 DUP 3 ;
+                                 DIG 3 ;
                                  CAR ;
                                  DUP ;
                                  CAR ;
@@ -1157,11 +1143,10 @@
                                  DUP 7 ;
                                  DIG 7 ;
                                  CDR ;
-                                 DIG 7 ;
-                                 DIG 7 ;
-                                 UPDATE 5 ;
+                                 DUP 7 ;
                                  SOME ;
-                                 DIG 8 ;
+                                 DIG 7 ;
+                                 CAR ;
                                  UPDATE ;
                                  UPDATE 2 ;
                                  UPDATE 2 ;
@@ -1424,8 +1409,7 @@
                { DIG 2 ;
                  DIG 3 ;
                  DIG 4 ;
-                 DIG 5 ;
-                 DROP 4 ;
+                 DROP 3 ;
                  IF_LEFT
                    { IF_LEFT
                        { DUP 2 ;
@@ -1525,18 +1509,21 @@
                                       { DUP 4 ;
                                         CAR ;
                                         CAR ;
-                                        CAR ;
                                         CDR ;
+                                        CAR ;
                                         DUP 5 ;
                                         CAR ;
                                         CAR ;
-                                        CDR ;
                                         CAR ;
-                                        DUP 2 ;
                                         CDR ;
-                                        DUP 3 ;
-                                        CAR ;
+                                        CDR ;
                                         DUP 6 ;
+                                        CAR ;
+                                        CAR ;
+                                        CAR ;
+                                        CDR ;
+                                        CAR ;
+                                        DUP 5 ;
                                         UNPAIR ;
                                         DUP ;
                                         DUP 3 ;
@@ -1549,6 +1536,11 @@
                                         GET ;
                                         IF_NONE
                                           { DROP ;
+                                            DUP 4 ;
+                                            CAR ;
+                                            CAR ;
+                                            CAR ;
+                                            CDR ;
                                             PUSH nat 0 ;
                                             DUP 2 ;
                                             CAR ;
@@ -1608,6 +1600,11 @@
                                                 DROP ;
                                                 IF_LEFT
                                                   { DROP 2 ;
+                                                    DUP 4 ;
+                                                    CAR ;
+                                                    CAR ;
+                                                    CAR ;
+                                                    CDR ;
                                                     PUSH nat 0 ;
                                                     DUP 2 ;
                                                     CAR ;
@@ -1660,11 +1657,11 @@
                                                        { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                                                     UPDATE ;
                                                     UPDATE 1 }
-                                                  { DIG 3 ; DROP 2 ; SWAP } }
+                                                  { DIG 2 ; DROP 2 ; DUP 4 ; CAR ; CAR ; CAR ; CDR } }
                                               { DUP 3 ;
                                                 INT ;
                                                 ADD ;
-                                                DIG 4 ;
+                                                DIG 3 ;
                                                 COMPARE ;
                                                 GE ;
                                                 IF { DUP ;
@@ -1690,16 +1687,21 @@
                                                                  (pair (pair string string) (pair int int) timestamp)) ;
                                                          LEFT timestamp ;
                                                          UPDATE 3 } ;
-                                                     DUP 2 ;
-                                                     DUP 3 ;
-                                                     CDR ;
-                                                     DUP 3 ;
-                                                     SOME ;
                                                      DUP 4 ;
+                                                     CAR ;
+                                                     CAR ;
+                                                     CAR ;
+                                                     CDR ;
+                                                     DUP ;
+                                                     DUP 2 ;
+                                                     CDR ;
+                                                     DUP 4 ;
+                                                     SOME ;
+                                                     DUP 5 ;
                                                      CAR ;
                                                      UPDATE ;
                                                      UPDATE 2 ;
-                                                     DIG 2 ;
+                                                     SWAP ;
                                                      CAR ;
                                                      DUP 3 ;
                                                      CAR ;
@@ -1715,7 +1717,7 @@
                                                         { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                                                      UPDATE ;
                                                      UPDATE 1 }
-                                                   { SWAP ; DROP ; SWAP } } } ;
+                                                   { SWAP ; DROP ; DUP 4 ; CAR ; CAR ; CAR ; CDR } } } ;
                                         SWAP ;
                                         DUP ;
                                         GET 3 ;
@@ -2378,7 +2380,7 @@
                          DUP 6 ;
                          GET ;
                          IF_NONE
-                           { DIG 6 ; DIG 7 ; DROP 2 ; SWAP }
+                           { DIG 6 ; DROP ; SWAP }
                            { DUP 7 ;
                              CAR ;
                              CAR ;
@@ -2533,20 +2535,20 @@
                                                             SWAP ;
                                                             GET 3 ;
                                                             INT ;
+                                                            PUSH int 1 ;
+                                                            SWAP ;
+                                                            PAIR ;
                                                             DIG 4 ;
                                                             INT ;
                                                             PUSH int 1 ;
                                                             SWAP ;
                                                             PAIR ;
-                                                            PUSH int 1 ;
-                                                            DIG 2 ;
-                                                            PAIR ;
-                                                            DUP ;
+                                                            DUP 2 ;
                                                             CAR ;
-                                                            DUP 3 ;
+                                                            DUP 2 ;
                                                             CDR ;
                                                             MUL ;
-                                                            SWAP ;
+                                                            DIG 2 ;
                                                             CDR ;
                                                             DUP 3 ;
                                                             CAR ;
@@ -2606,12 +2608,36 @@
                                                                { SWAP } ;
                                                             DUP ;
                                                             CDR ;
+                                                            PUSH nat 1 ;
                                                             PUSH nat 0 ;
                                                             PUSH nat 10 ;
                                                             PAIR ;
-                                                            DUP 23 ;
-                                                            SWAP ;
-                                                            EXEC ;
+                                                            PAIR ;
+                                                            LEFT nat ;
+                                                            LOOP_LEFT
+                                                              { UNPAIR ;
+                                                                UNPAIR ;
+                                                                PUSH nat 0 ;
+                                                                DUP 3 ;
+                                                                COMPARE ;
+                                                                EQ ;
+                                                                IF { DROP 2 ; RIGHT (pair (pair nat nat) nat) }
+                                                                   { PUSH nat 1 ;
+                                                                     PUSH nat 1 ;
+                                                                     DUP 4 ;
+                                                                     AND ;
+                                                                     COMPARE ;
+                                                                     EQ ;
+                                                                     IF { DUP ; DIG 3 ; MUL } { DIG 2 } ;
+                                                                     PUSH nat 1 ;
+                                                                     DIG 3 ;
+                                                                     LSR ;
+                                                                     DUP 3 ;
+                                                                     DIG 3 ;
+                                                                     MUL ;
+                                                                     PAIR ;
+                                                                     PAIR ;
+                                                                     LEFT nat } } ;
                                                             DIG 2 ;
                                                             CAR ;
                                                             MUL ;
@@ -2653,12 +2679,36 @@
                                                                     { SWAP } ;
                                                                  DUP ;
                                                                  CDR ;
+                                                                 PUSH nat 1 ;
                                                                  PUSH nat 0 ;
                                                                  PUSH nat 10 ;
                                                                  PAIR ;
-                                                                 DUP 21 ;
-                                                                 SWAP ;
-                                                                 EXEC ;
+                                                                 PAIR ;
+                                                                 LEFT nat ;
+                                                                 LOOP_LEFT
+                                                                   { UNPAIR ;
+                                                                     UNPAIR ;
+                                                                     PUSH nat 0 ;
+                                                                     DUP 3 ;
+                                                                     COMPARE ;
+                                                                     EQ ;
+                                                                     IF { DROP 2 ; RIGHT (pair (pair nat nat) nat) }
+                                                                        { PUSH nat 1 ;
+                                                                          PUSH nat 1 ;
+                                                                          DUP 4 ;
+                                                                          AND ;
+                                                                          COMPARE ;
+                                                                          EQ ;
+                                                                          IF { DUP ; DIG 3 ; MUL } { DIG 2 } ;
+                                                                          PUSH nat 1 ;
+                                                                          DIG 3 ;
+                                                                          LSR ;
+                                                                          DUP 3 ;
+                                                                          DIG 3 ;
+                                                                          MUL ;
+                                                                          PAIR ;
+                                                                          PAIR ;
+                                                                          LEFT nat } } ;
                                                                  DIG 2 ;
                                                                  CAR ;
                                                                  MUL ;
@@ -2683,20 +2733,20 @@
                                                             SWAP ;
                                                             GET 6 ;
                                                             INT ;
+                                                            PUSH int 1 ;
+                                                            SWAP ;
+                                                            PAIR ;
                                                             DIG 4 ;
                                                             INT ;
                                                             PUSH int 1 ;
                                                             SWAP ;
                                                             PAIR ;
-                                                            PUSH int 1 ;
-                                                            DIG 2 ;
-                                                            PAIR ;
-                                                            DUP ;
+                                                            DUP 2 ;
                                                             CAR ;
-                                                            DUP 3 ;
+                                                            DUP 2 ;
                                                             CDR ;
                                                             MUL ;
-                                                            SWAP ;
+                                                            DIG 2 ;
                                                             CDR ;
                                                             DUP 3 ;
                                                             CAR ;
@@ -2756,12 +2806,36 @@
                                                                { SWAP } ;
                                                             DUP ;
                                                             CDR ;
+                                                            PUSH nat 1 ;
                                                             PUSH nat 0 ;
                                                             PUSH nat 10 ;
                                                             PAIR ;
-                                                            DUP 23 ;
-                                                            SWAP ;
-                                                            EXEC ;
+                                                            PAIR ;
+                                                            LEFT nat ;
+                                                            LOOP_LEFT
+                                                              { UNPAIR ;
+                                                                UNPAIR ;
+                                                                PUSH nat 0 ;
+                                                                DUP 3 ;
+                                                                COMPARE ;
+                                                                EQ ;
+                                                                IF { DROP 2 ; RIGHT (pair (pair nat nat) nat) }
+                                                                   { PUSH nat 1 ;
+                                                                     PUSH nat 1 ;
+                                                                     DUP 4 ;
+                                                                     AND ;
+                                                                     COMPARE ;
+                                                                     EQ ;
+                                                                     IF { DUP ; DIG 3 ; MUL } { DIG 2 } ;
+                                                                     PUSH nat 1 ;
+                                                                     DIG 3 ;
+                                                                     LSR ;
+                                                                     DUP 3 ;
+                                                                     DIG 3 ;
+                                                                     MUL ;
+                                                                     PAIR ;
+                                                                     PAIR ;
+                                                                     LEFT nat } } ;
                                                             DIG 2 ;
                                                             CAR ;
                                                             MUL ;
@@ -2803,12 +2877,36 @@
                                                                     { SWAP } ;
                                                                  DUP ;
                                                                  CDR ;
+                                                                 PUSH nat 1 ;
                                                                  PUSH nat 0 ;
                                                                  PUSH nat 10 ;
                                                                  PAIR ;
-                                                                 DUP 21 ;
-                                                                 SWAP ;
-                                                                 EXEC ;
+                                                                 PAIR ;
+                                                                 LEFT nat ;
+                                                                 LOOP_LEFT
+                                                                   { UNPAIR ;
+                                                                     UNPAIR ;
+                                                                     PUSH nat 0 ;
+                                                                     DUP 3 ;
+                                                                     COMPARE ;
+                                                                     EQ ;
+                                                                     IF { DROP 2 ; RIGHT (pair (pair nat nat) nat) }
+                                                                        { PUSH nat 1 ;
+                                                                          PUSH nat 1 ;
+                                                                          DUP 4 ;
+                                                                          AND ;
+                                                                          COMPARE ;
+                                                                          EQ ;
+                                                                          IF { DUP ; DIG 3 ; MUL } { DIG 2 } ;
+                                                                          PUSH nat 1 ;
+                                                                          DIG 3 ;
+                                                                          LSR ;
+                                                                          DUP 3 ;
+                                                                          DIG 3 ;
+                                                                          MUL ;
+                                                                          PAIR ;
+                                                                          PAIR ;
+                                                                          LEFT nat } } ;
                                                                  DIG 2 ;
                                                                  CAR ;
                                                                  MUL ;
@@ -2904,8 +3002,7 @@
                                     PAIR ;
                                     PAIR } ;
                              DIG 5 ;
-                             DIG 6 ;
-                             DROP 2 ;
+                             DROP ;
                              UNPAIR ;
                              CAR ;
                              UNPAIR ;
@@ -3016,8 +3113,7 @@
                          UPDATE 2 ;
                          SWAP }
                        { DIG 2 ;
-                         DIG 3 ;
-                         DROP 2 ;
+                         DROP ;
                          DUP 2 ;
                          CAR ;
                          CAR ;
@@ -3059,8 +3155,7 @@
                      IF_LEFT
                        { DIG 2 ;
                          DIG 3 ;
-                         DIG 4 ;
-                         DROP 3 ;
+                         DROP 2 ;
                          DUP 2 ;
                          CAR ;
                          CAR ;
@@ -3441,7 +3536,7 @@
                          DUP 2 ;
                          GET ;
                          IF_NONE
-                           { DROP 5 ; PUSH nat 117 ; FAILWITH }
+                           { DROP 4 ; PUSH nat 117 ; FAILWITH }
                            { DUP 3 ;
                              CDR ;
                              CDR ;
@@ -3570,17 +3665,17 @@
                                 { INT ; PUSH int 10 ; PAIR ; DUP 7 ; SWAP ; EXEC ; DIG 3 } ;
                              INT ;
                              PUSH int 1 ;
-                             DIG 2 ;
+                             SWAP ;
                              PAIR ;
                              PUSH int 1 ;
                              DIG 2 ;
                              PAIR ;
-                             DUP 2 ;
+                             DUP ;
                              CAR ;
-                             DUP 2 ;
+                             DUP 3 ;
                              CDR ;
                              MUL ;
-                             DIG 2 ;
+                             SWAP ;
                              CDR ;
                              DIG 2 ;
                              CAR ;
@@ -3696,26 +3791,26 @@
                              CAR ;
                              UNIT ;
                              LEFT unit ;
-                             IF_LEFT { DROP } { DROP ; DUP ; CAR ; SWAP ; CDR ; PAIR } ;
+                             PAIR ;
                              NOW ;
                              DUP 3 ;
                              CAR ;
                              CAR ;
-                             CDR ;
                              CAR ;
+                             CDR ;
+                             DIG 2 ;
+                             UNPAIR ;
+                             IF_LEFT { DROP } { DROP ; DUP ; CAR ; SWAP ; CDR ; PAIR } ;
                              DUP 4 ;
                              CAR ;
                              CAR ;
-                             CAR ;
-                             CDR ;
-                             CDR ;
-                             DUP 5 ;
-                             CAR ;
-                             CAR ;
-                             CAR ;
                              CDR ;
                              CAR ;
-                             DUP 5 ;
+                             DUP 3 ;
+                             CDR ;
+                             DUP 4 ;
+                             CAR ;
+                             DUP 4 ;
                              UNPAIR ;
                              DUP ;
                              DUP 3 ;
@@ -3727,13 +3822,7 @@
                              IF_NONE { PUSH nat 0 } {} ;
                              GET ;
                              IF_NONE
-                               { DIG 2 ;
-                                 DROP 2 ;
-                                 DUP 2 ;
-                                 CAR ;
-                                 CAR ;
-                                 CAR ;
-                                 CDR ;
+                               { DROP 2 ;
                                  NONE (pair nat
                                             (or (or (pair (pair timestamp
                                                                 (pair (pair nat nat nat)
@@ -3750,27 +3839,21 @@
                                  IF_LEFT
                                    { IF_LEFT { DROP ; PUSH bool True } { DROP ; PUSH bool False } }
                                    { DROP ; PUSH bool False } ;
-                                 IF { SWAP ; DIG 3 ; DROP 2 ; DUP 3 ; CAR ; CAR ; CAR ; CDR }
-                                    { DUP 5 ;
-                                      CAR ;
-                                      CAR ;
-                                      CAR ;
-                                      CDR ;
-                                      DUP 2 ;
+                                 IF { SWAP ; DIG 2 ; DROP 2 }
+                                    { DUP ;
                                       GET 3 ;
                                       IF_LEFT
-                                        { DIG 3 ;
+                                        { DIG 2 ;
                                           DROP ;
                                           IF_LEFT
-                                            { DIG 2 ;
-                                              DROP 2 ;
+                                            { DROP 2 ;
                                               PUSH nat 0 ;
-                                              DUP 2 ;
+                                              DUP 3 ;
                                               CAR ;
                                               ITER { CDR ; DUP 2 ; DUP 2 ; COMPARE ; GT ; IF { SWAP ; DROP } { DROP } } ;
                                               PUSH nat 1 ;
                                               ADD ;
-                                              DIG 3 ;
+                                              SWAP ;
                                               PUSH nat 0 ;
                                               PUSH nat 0 ;
                                               PUSH nat 0 ;
@@ -3816,25 +3899,25 @@
                                                  { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                                               UPDATE ;
                                               UPDATE 1 }
-                                            { DIG 4 ; DROP 2 } }
-                                        { DIG 5 ;
+                                            { DIG 2 ; DROP 2 ; SWAP } }
+                                        { DIG 3 ;
                                           DROP ;
-                                          DUP 4 ;
+                                          DUP 3 ;
                                           INT ;
                                           ADD ;
                                           DUP 5 ;
                                           COMPARE ;
                                           GE ;
-                                          IF { DUP 2 ;
+                                          IF { DUP ;
                                                GET 3 ;
                                                IF_LEFT
-                                                 { DIG 2 ;
-                                                   DIG 3 ;
+                                                 { SWAP ;
+                                                   DIG 2 ;
                                                    DROP 2 ;
                                                    IF_LEFT
                                                      { DROP ; PUSH nat 105 ; FAILWITH }
                                                      { DROP ; PUSH nat 105 ; FAILWITH } }
-                                                 { DIG 3 ;
+                                                 { DIG 2 ;
                                                    INT ;
                                                    DUP 2 ;
                                                    ADD ;
@@ -3847,8 +3930,6 @@
                                                                        (pair (pair string string) (pair int int) timestamp)))
                                                            (pair (pair string string) (pair int int) timestamp)) ;
                                                    LEFT timestamp ;
-                                                   DIG 2 ;
-                                                   SWAP ;
                                                    UPDATE 3 } ;
                                                DUP 2 ;
                                                DUP 3 ;
@@ -3875,11 +3956,11 @@
                                                   { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                                                UPDATE ;
                                                UPDATE 1 }
-                                             { DIG 2 ; DROP } } } ;
-                                 SWAP ;
+                                             { SWAP ; DROP ; SWAP } } ;
+                                      SWAP } ;
                                  SOME } ;
                              IF_NONE
-                               { SWAP ; DIG 3 ; DIG 4 ; DIG 5 ; DROP 5 }
+                               { SWAP ; DIG 3 ; DIG 4 ; DROP 4 }
                                { DUP ;
                                  GET 3 ;
                                  IF_LEFT
@@ -4075,12 +4156,36 @@
                                          { DUP 3 } ;
                                       DUP ;
                                       CDR ;
+                                      PUSH nat 1 ;
                                       PUSH nat 0 ;
                                       PUSH nat 10 ;
                                       PAIR ;
-                                      DUP 14 ;
-                                      SWAP ;
-                                      EXEC ;
+                                      PAIR ;
+                                      LEFT nat ;
+                                      LOOP_LEFT
+                                        { UNPAIR ;
+                                          UNPAIR ;
+                                          PUSH nat 0 ;
+                                          DUP 3 ;
+                                          COMPARE ;
+                                          EQ ;
+                                          IF { DROP 2 ; RIGHT (pair (pair nat nat) nat) }
+                                             { PUSH nat 1 ;
+                                               PUSH nat 1 ;
+                                               DUP 4 ;
+                                               AND ;
+                                               COMPARE ;
+                                               EQ ;
+                                               IF { DUP ; DIG 3 ; MUL } { DIG 2 } ;
+                                               PUSH nat 1 ;
+                                               DIG 3 ;
+                                               LSR ;
+                                               DUP 3 ;
+                                               DIG 3 ;
+                                               MUL ;
+                                               PAIR ;
+                                               PAIR ;
+                                               LEFT nat } } ;
                                       DIG 2 ;
                                       CAR ;
                                       MUL ;
@@ -4098,12 +4203,36 @@
                                          { DUP 3 } ;
                                       DUP ;
                                       CDR ;
+                                      PUSH nat 1 ;
                                       PUSH nat 0 ;
                                       PUSH nat 10 ;
                                       PAIR ;
-                                      DUP 15 ;
-                                      SWAP ;
-                                      EXEC ;
+                                      PAIR ;
+                                      LEFT nat ;
+                                      LOOP_LEFT
+                                        { UNPAIR ;
+                                          UNPAIR ;
+                                          PUSH nat 0 ;
+                                          DUP 3 ;
+                                          COMPARE ;
+                                          EQ ;
+                                          IF { DROP 2 ; RIGHT (pair (pair nat nat) nat) }
+                                             { PUSH nat 1 ;
+                                               PUSH nat 1 ;
+                                               DUP 4 ;
+                                               AND ;
+                                               COMPARE ;
+                                               EQ ;
+                                               IF { DUP ; DIG 3 ; MUL } { DIG 2 } ;
+                                               PUSH nat 1 ;
+                                               DIG 3 ;
+                                               LSR ;
+                                               DUP 3 ;
+                                               DIG 3 ;
+                                               MUL ;
+                                               PAIR ;
+                                               PAIR ;
+                                               LEFT nat } } ;
                                       DIG 2 ;
                                       CAR ;
                                       MUL ;
@@ -4121,12 +4250,36 @@
                                          { DUP 3 } ;
                                       DUP ;
                                       CDR ;
+                                      PUSH nat 1 ;
                                       PUSH nat 0 ;
                                       PUSH nat 10 ;
                                       PAIR ;
-                                      DUP 16 ;
-                                      SWAP ;
-                                      EXEC ;
+                                      PAIR ;
+                                      LEFT nat ;
+                                      LOOP_LEFT
+                                        { UNPAIR ;
+                                          UNPAIR ;
+                                          PUSH nat 0 ;
+                                          DUP 3 ;
+                                          COMPARE ;
+                                          EQ ;
+                                          IF { DROP 2 ; RIGHT (pair (pair nat nat) nat) }
+                                             { PUSH nat 1 ;
+                                               PUSH nat 1 ;
+                                               DUP 4 ;
+                                               AND ;
+                                               COMPARE ;
+                                               EQ ;
+                                               IF { DUP ; DIG 3 ; MUL } { DIG 2 } ;
+                                               PUSH nat 1 ;
+                                               DIG 3 ;
+                                               LSR ;
+                                               DUP 3 ;
+                                               DIG 3 ;
+                                               MUL ;
+                                               PAIR ;
+                                               PAIR ;
+                                               LEFT nat } } ;
                                       DIG 2 ;
                                       CAR ;
                                       MUL ;
@@ -4313,12 +4466,36 @@
                                          {} ;
                                       DUP ;
                                       CDR ;
+                                      PUSH nat 1 ;
                                       PUSH nat 0 ;
                                       PUSH nat 10 ;
                                       PAIR ;
-                                      DIG 13 ;
-                                      SWAP ;
-                                      EXEC ;
+                                      PAIR ;
+                                      LEFT nat ;
+                                      LOOP_LEFT
+                                        { UNPAIR ;
+                                          UNPAIR ;
+                                          PUSH nat 0 ;
+                                          DUP 3 ;
+                                          COMPARE ;
+                                          EQ ;
+                                          IF { DROP 2 ; RIGHT (pair (pair nat nat) nat) }
+                                             { PUSH nat 1 ;
+                                               PUSH nat 1 ;
+                                               DUP 4 ;
+                                               AND ;
+                                               COMPARE ;
+                                               EQ ;
+                                               IF { DUP ; DIG 3 ; MUL } { DIG 2 } ;
+                                               PUSH nat 1 ;
+                                               DIG 3 ;
+                                               LSR ;
+                                               DUP 3 ;
+                                               DIG 3 ;
+                                               MUL ;
+                                               PAIR ;
+                                               PAIR ;
+                                               LEFT nat } } ;
                                       DIG 2 ;
                                       CAR ;
                                       MUL ;
@@ -4370,7 +4547,7 @@
                                          { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                                       UPDATE ;
                                       UPDATE 1 }
-                                    { DIG 3 ; DIG 4 ; DIG 5 ; DROP 4 } ;
+                                    { DIG 3 ; DIG 4 ; DROP 3 } ;
                                  DUP 2 ;
                                  DIG 2 ;
                                  CAR ;

--- a/batcher/batcher-ghostnet.tz
+++ b/batcher/batcher-ghostnet.tz
@@ -658,12 +658,7 @@
                                             CAR ;
                                             CAR ;
                                             GET 3 ;
-                                            PAIR ;
                                             SWAP ;
-                                            DUP 2 ;
-                                            CAR ;
-                                            DIG 2 ;
-                                            CDR ;
                                             DIG 3 ;
                                             DUP 5 ;
                                             GET 8 ;
@@ -2431,32 +2426,40 @@
                          PAIR ;
                          PAIR ;
                          DUP 4 ;
+                         CAR ;
+                         CAR ;
+                         CDR ;
+                         CAR ;
+                         DUP 5 ;
                          CDR ;
                          CAR ;
                          CDR ;
                          CDR ;
-                         EMPTY_MAP string (pair (pair nat string (option address) nat (option string)) nat) ;
-                         DUP 2 ;
                          DUP 6 ;
+                         CAR ;
+                         CAR ;
+                         CAR ;
+                         CDR ;
+                         EMPTY_MAP string (pair (pair nat string (option address) nat (option string)) nat) ;
+                         DUP 3 ;
+                         DUP 8 ;
                          GET ;
                          IF_NONE
-                           { DIG 6 ; DIG 7 ; DROP 2 ; SWAP }
-                           { DUP 7 ;
+                           { DIG 8 ; DIG 9 ; DROP 2 ; DIG 3 ; DIG 2 ; PAIR ; DIG 2 }
+                           { DIG 2 ;
+                             DUP 9 ;
                              CAR ;
                              CDR ;
                              CAR ;
                              CAR ;
-                             DIG 4 ;
+                             DIG 6 ;
                              PAIR ;
-                             DUP 7 ;
-                             CDR ;
-                             CDR ;
-                             CDR ;
+                             PAIR ;
                              DUP 8 ;
-                             CAR ;
-                             CAR ;
                              CDR ;
-                             CAR ;
+                             CDR ;
+                             CDR ;
+                             DIG 5 ;
                              PAIR ;
                              DIG 3 ;
                              DUP 4 ;
@@ -2472,14 +2475,15 @@
                                     UNPAIR ;
                                     DIG 4 ;
                                     UNPAIR ;
-                                    DIG 6 ;
                                     UNPAIR ;
-                                    DUP 5 ;
+                                    DIG 7 ;
+                                    UNPAIR ;
+                                    DUP 6 ;
                                     CDR ;
                                     DUP 2 ;
                                     GET ;
                                     IF_NONE
-                                      { DROP 2 ; PAIR ; DUG 2 ; PAIR ; DIG 3 ; DIG 3 }
+                                      { DROP 2 ; PAIR ; PAIR ; DUG 2 ; PAIR ; DIG 3 ; DIG 3 }
                                       { DUP ;
                                         GET 3 ;
                                         IF_LEFT
@@ -2496,20 +2500,20 @@
                                                        (pair nat nat nat nat)
                                                        (pair (pair string string) (pair int int) timestamp)) } ;
                                         IF_NONE
-                                          { DROP 3 ; PAIR ; DUG 2 ; PAIR ; DIG 3 ; DIG 3 }
+                                          { DROP 3 ; PAIR ; PAIR ; DUG 2 ; PAIR ; DIG 3 ; DIG 3 }
                                           { DUP 6 ;
                                             DIG 5 ;
                                             PAIR ;
-                                            DUP 8 ;
-                                            DIG 3 ;
+                                            DUP 9 ;
+                                            DUP 4 ;
                                             GET 5 ;
                                             PAIR ;
-                                            DIG 9 ;
+                                            DIG 11 ;
                                             DIG 3 ;
                                             PAIR ;
                                             PAIR ;
                                             PAIR ;
-                                            DIG 2 ;
+                                            DIG 3 ;
                                             ITER { SWAP ;
                                                    UNPAIR ;
                                                    UNPAIR ;
@@ -2672,7 +2676,7 @@
                                                             PUSH nat 0 ;
                                                             PUSH nat 10 ;
                                                             PAIR ;
-                                                            DUP 23 ;
+                                                            DUP 25 ;
                                                             SWAP ;
                                                             EXEC ;
                                                             DIG 2 ;
@@ -2690,7 +2694,7 @@
                                                             CDR ;
                                                             COMPARE ;
                                                             GT ;
-                                                            IF { DIG 8 ; SWAP ; PAIR ; DUP 18 ; SWAP ; EXEC } { DROP ; DIG 7 } ;
+                                                            IF { DIG 8 ; SWAP ; PAIR ; DUP 20 ; SWAP ; EXEC } { DROP ; DIG 7 } ;
                                                             PUSH int 1 ;
                                                             PUSH int 0 ;
                                                             PAIR ;
@@ -2719,7 +2723,7 @@
                                                                  PUSH nat 0 ;
                                                                  PUSH nat 10 ;
                                                                  PAIR ;
-                                                                 DUP 21 ;
+                                                                 DUP 23 ;
                                                                  SWAP ;
                                                                  EXEC ;
                                                                  DIG 2 ;
@@ -2733,7 +2737,7 @@
                                                                  DIG 2 ;
                                                                  PAIR ;
                                                                  PAIR ;
-                                                                 DUP 16 ;
+                                                                 DUP 18 ;
                                                                  SWAP ;
                                                                  EXEC }
                                                                { SWAP ; DIG 2 ; DROP 2 } }
@@ -2822,7 +2826,7 @@
                                                             PUSH nat 0 ;
                                                             PUSH nat 10 ;
                                                             PAIR ;
-                                                            DUP 23 ;
+                                                            DUP 25 ;
                                                             SWAP ;
                                                             EXEC ;
                                                             DIG 2 ;
@@ -2840,7 +2844,7 @@
                                                             CDR ;
                                                             COMPARE ;
                                                             GT ;
-                                                            IF { DIG 8 ; SWAP ; PAIR ; DUP 18 ; SWAP ; EXEC } { DROP ; DIG 7 } ;
+                                                            IF { DIG 8 ; SWAP ; PAIR ; DUP 20 ; SWAP ; EXEC } { DROP ; DIG 7 } ;
                                                             PUSH int 1 ;
                                                             PUSH int 0 ;
                                                             PAIR ;
@@ -2869,7 +2873,7 @@
                                                                  PUSH nat 0 ;
                                                                  PUSH nat 10 ;
                                                                  PAIR ;
-                                                                 DUP 21 ;
+                                                                 DUP 23 ;
                                                                  SWAP ;
                                                                  EXEC ;
                                                                  DIG 2 ;
@@ -2883,7 +2887,7 @@
                                                                  DIG 2 ;
                                                                  PAIR ;
                                                                  PAIR ;
-                                                                 DUP 16 ;
+                                                                 DUP 18 ;
                                                                  SWAP ;
                                                                  EXEC }
                                                                { SWAP ; DIG 2 ; DROP 2 } } ;
@@ -2933,7 +2937,7 @@
                                                         DIG 3 ;
                                                         PAIR ;
                                                         PAIR ;
-                                                        DUP 16 ;
+                                                        DUP 18 ;
                                                         SWAP ;
                                                         EXEC } ;
                                                    DUG 2 ;
@@ -2951,11 +2955,53 @@
                                             CDR ;
                                             SWAP ;
                                             CAR ;
+                                            DUP 3 ;
+                                            CAR ;
+                                            DUP 7 ;
+                                            DUP 2 ;
+                                            GET ;
+                                            IF_NONE
+                                              { DIG 6 ; DROP 2 ; PUSH nat 141 ; FAILWITH }
+                                              { PUSH nat 1 ;
+                                                SWAP ;
+                                                SUB ;
+                                                ABS ;
+                                                PUSH nat 0 ;
+                                                DUP 2 ;
+                                                COMPARE ;
+                                                GT ;
+                                                IF { DIG 7 ; SWAP ; SOME ; DIG 2 ; UPDATE }
+                                                   { DROP ; DIG 6 ; SWAP ; NONE nat ; SWAP ; UPDATE } } ;
+                                            DUP ;
+                                            DIG 6 ;
                                             DIG 3 ;
-                                            SWAP ;
                                             PAIR ;
-                                            DIG 4 ;
-                                            DIG 4 ;
+                                            PAIR ;
+                                            DIG 6 ;
+                                            DIG 2 ;
+                                            DUP 5 ;
+                                            CAR ;
+                                            MEM ;
+                                            IF { DUP 6 ;
+                                                 DIG 6 ;
+                                                 CDR ;
+                                                 DIG 5 ;
+                                                 CAR ;
+                                                 NONE (pair nat
+                                                            (or (or (pair (pair timestamp
+                                                                                (pair (pair nat nat nat)
+                                                                                      (or (or unit unit) unit)
+                                                                                      (pair nat nat nat nat)
+                                                                                      (pair (pair string string) (pair int int) timestamp)))
+                                                                          (pair (pair string string) (pair int int) timestamp))
+                                                                    (pair timestamp timestamp))
+                                                                timestamp)
+                                                            (pair nat nat nat nat nat nat nat nat)
+                                                            (pair string string)) ;
+                                                 SWAP ;
+                                                 UPDATE ;
+                                                 UPDATE 2 }
+                                               { DIG 3 ; DROP ; DIG 4 } ;
                                             PAIR ;
                                             DIG 2 ;
                                             DIG 4 ;
@@ -2970,19 +3016,27 @@
                              DIG 6 ;
                              DROP 2 ;
                              UNPAIR ;
-                             CAR ;
+                             UNPAIR ;
                              UNPAIR ;
                              DIG 2 ;
                              CAR ;
-                             DIG 2 ;
+                             DIG 3 ;
+                             UNPAIR ;
+                             CAR ;
+                             DIG 4 ;
                              DIG 3 ;
                              DIG 3 ;
+                             PAIR ;
+                             DIG 4 ;
+                             DIG 4 ;
                              SOME ;
-                             DUP 6 ;
+                             DUP 7 ;
                              UPDATE } ;
-                         DIG 2 ;
-                         NIL operation ;
                          DIG 3 ;
+                         DIG 2 ;
+                         UNPAIR ;
+                         NIL operation ;
+                         DIG 5 ;
                          ITER { CDR ;
                                 DUP ;
                                 CAR ;
@@ -3004,8 +3058,8 @@
                                              PUSH mutez 0 ;
                                              DIG 2 ;
                                              CDR ;
-                                             DUP 8 ;
-                                             DUP 8 ;
+                                             DUP 10 ;
+                                             DUP 10 ;
                                              PAIR 3 ;
                                              TRANSFER_TOKENS }
                                            { PUSH string "FA2 token" ;
@@ -3023,60 +3077,82 @@
                                                   DIG 5 ;
                                                   CAR ;
                                                   CAR ;
-                                                  DUP 11 ;
+                                                  DUP 13 ;
                                                   PAIR 3 ;
                                                   CONS ;
-                                                  DUP 8 ;
+                                                  DUP 10 ;
                                                   PAIR ;
                                                   CONS ;
                                                   TRANSFER_TOKENS }
                                                 { DROP 2 ; PUSH nat 108 ; FAILWITH } } } } ;
                                 CONS } ;
-                         DIG 3 ;
-                         DIG 4 ;
+                         DIG 5 ;
+                         DIG 6 ;
                          DROP 2 ;
                          PUSH mutez 0 ;
-                         DUP 3 ;
+                         DUP 5 ;
                          CDR ;
                          CDR ;
                          COMPARE ;
                          GT ;
-                         IF { DUP 2 ;
+                         IF { DUP 4 ;
                               CAR ;
                               CDR ;
                               CONTRACT unit ;
                               IF_NONE
                                 { PUSH nat 102 ; FAILWITH }
-                                { DUP 3 ; CDR ; CDR ; UNIT ; TRANSFER_TOKENS } ;
+                                { DUP 5 ; CDR ; CDR ; UNIT ; TRANSFER_TOKENS } ;
                               CONS }
                             {} ;
                          PUSH mutez 0 ;
-                         DUP 3 ;
+                         DUP 5 ;
                          CDR ;
                          CAR ;
                          COMPARE ;
                          GT ;
-                         IF { DUP 2 ;
+                         IF { DUP 4 ;
                               CAR ;
                               CAR ;
                               CONTRACT unit ;
                               IF_NONE
-                                { SWAP ; DROP ; PUSH nat 102 ; FAILWITH }
-                                { DIG 2 ; CDR ; CAR ; UNIT ; TRANSFER_TOKENS } ;
+                                { DIG 3 ; DROP ; PUSH nat 102 ; FAILWITH }
+                                { DIG 4 ; CDR ; CAR ; UNIT ; TRANSFER_TOKENS } ;
                               CONS }
-                            { SWAP ; DROP } ;
-                         DUP 3 ;
-                         DIG 3 ;
+                            { DIG 3 ; DROP } ;
+                         DUP 5 ;
+                         DIG 5 ;
                          CDR ;
+                         DUP ;
+                         CAR ;
+                         DUP ;
+                         CDR ;
+                         DIG 7 ;
+                         UPDATE 2 ;
+                         UPDATE 2 ;
+                         UPDATE 1 ;
+                         UPDATE 2 ;
+                         DUP ;
+                         CAR ;
+                         DUP ;
+                         CAR ;
+                         DUP ;
+                         CAR ;
+                         DIG 5 ;
+                         UPDATE 2 ;
+                         UPDATE 1 ;
+                         UPDATE 1 ;
+                         UPDATE 1 ;
+                         DUP ;
+                         CAR ;
                          DUP ;
                          CAR ;
                          DUP ;
                          CDR ;
                          DIG 5 ;
-                         UPDATE 2 ;
-                         UPDATE 2 ;
                          UPDATE 1 ;
                          UPDATE 2 ;
+                         UPDATE 1 ;
+                         UPDATE 1 ;
                          SWAP }
                        { DIG 2 ;
                          DIG 3 ;

--- a/batcher/batcher-ghostnet.tz
+++ b/batcher/batcher-ghostnet.tz
@@ -72,67 +72,67 @@
                        (bool %is_disabled_for_deposits))
                     (string %tick))))) ;
   storage
-    (pair (pair (pair (pair (address %administrator)
-                            (pair %batch_set
-                               (map %current_batch_indices string nat)
-                               (big_map %batches
-                                  nat
-                                  (pair (nat %batch_number)
-                                        (or %status
-                                           (or (pair %cleared
-                                                  (pair (timestamp %at)
-                                                        (pair %clearing
-                                                           (pair %clearing_volumes (nat %minus) (nat %exact) (nat %plus))
-                                                           (or %clearing_tolerance (or (unit %exact) (unit %minus)) (unit %plus))
-                                                           (pair %total_cleared_volumes
-                                                              (nat %buy_side_total_cleared_volume)
-                                                              (nat %buy_side_volume_subject_to_clearing)
-                                                              (nat %sell_side_total_cleared_volume)
-                                                              (nat %sell_side_volume_subject_to_clearing))
-                                                           (pair %clearing_rate
-                                                              (pair %swap (string %from) (string %to))
-                                                              (pair %rate (int %p) (int %q))
-                                                              (timestamp %when))))
-                                                  (pair %rate
-                                                     (pair %swap (string %from) (string %to))
-                                                     (pair %rate (int %p) (int %q))
-                                                     (timestamp %when)))
-                                               (pair %closed (timestamp %closing_time) (timestamp %start_time)))
-                                           (timestamp %open))
-                                        (pair %volumes
-                                           (nat %buy_minus_volume)
-                                           (nat %buy_exact_volume)
-                                           (nat %buy_plus_volume)
-                                           (nat %buy_total_volume)
-                                           (nat %sell_minus_volume)
-                                           (nat %sell_exact_volume)
-                                           (nat %sell_plus_volume)
-                                           (nat %sell_total_volume))
-                                        (pair %pair string string)))))
-                      (nat %deposit_time_window_in_seconds)
-                      (mutez %fee_in_mutez))
-                (pair (address %fee_recipient) (nat %last_order_number))
-                (nat %limit_on_tokens_or_pairs)
-                (big_map %metadata string bytes))
-          (pair (pair (big_map %rates_current
+    (pair (pair (pair (pair (address %administrator) (big_map %batch_holdings nat nat))
+                      (pair %batch_set
+                         (map %current_batch_indices string nat)
+                         (big_map %batches
+                            nat
+                            (pair (nat %batch_number)
+                                  (or %status
+                                     (or (pair %cleared
+                                            (pair (timestamp %at)
+                                                  (pair %clearing
+                                                     (pair %clearing_volumes (nat %minus) (nat %exact) (nat %plus))
+                                                     (or %clearing_tolerance (or (unit %exact) (unit %minus)) (unit %plus))
+                                                     (pair %total_cleared_volumes
+                                                        (nat %buy_side_total_cleared_volume)
+                                                        (nat %buy_side_volume_subject_to_clearing)
+                                                        (nat %sell_side_total_cleared_volume)
+                                                        (nat %sell_side_volume_subject_to_clearing))
+                                                     (pair %clearing_rate
+                                                        (pair %swap (string %from) (string %to))
+                                                        (pair %rate (int %p) (int %q))
+                                                        (timestamp %when))))
+                                            (pair %rate
+                                               (pair %swap (string %from) (string %to))
+                                               (pair %rate (int %p) (int %q))
+                                               (timestamp %when)))
+                                         (pair %closed (timestamp %closing_time) (timestamp %start_time)))
+                                     (timestamp %open))
+                                  (pair %volumes
+                                     (nat %buy_minus_volume)
+                                     (nat %buy_exact_volume)
+                                     (nat %buy_plus_volume)
+                                     (nat %buy_total_volume)
+                                     (nat %sell_minus_volume)
+                                     (nat %sell_exact_volume)
+                                     (nat %sell_plus_volume)
+                                     (nat %sell_total_volume))
+                                  (pair %pair string string))))
+                      (nat %deposit_time_window_in_seconds))
+                (pair (mutez %fee_in_mutez) (address %fee_recipient))
+                (nat %last_order_number)
+                (nat %limit_on_tokens_or_pairs))
+          (pair (pair (big_map %metadata string bytes)
+                      (big_map %rates_current
                          string
                          (pair (pair %swap (string %from) (string %to))
                                (pair %rate (int %p) (int %q))
-                               (timestamp %when)))
-                      (nat %scale_factor_for_oracle_staleness))
+                               (timestamp %when))))
+                (nat %scale_factor_for_oracle_staleness)
                 (big_map %user_batch_ordertypes
                    address
                    (map nat
                         (map (pair (or %side (unit %buy) (unit %sell))
                                    (or %tolerance (or (unit %exact) (unit %minus)) (unit %plus)))
-                             nat)))
-                (map %valid_swaps
-                   string
-                   (pair (pair %swap (string %from) (string %to))
-                         (address %oracle_address)
-                         (string %oracle_asset_name)
-                         (nat %oracle_precision)
-                         (bool %is_disabled_for_deposits))))
+                             nat))))
+          (map %valid_swaps
+             string
+             (pair (pair %swap (string %from) (string %to))
+                   (address %oracle_address)
+                   (string %oracle_asset_name)
+                   (nat %oracle_precision)
+                   (bool %is_disabled_for_deposits)))
           (map %valid_tokens
              string
              (pair (nat %token_id)
@@ -140,7 +140,40 @@
                    (option %address address)
                    (nat %decimals)
                    (option %standard string)))) ;
-  code { PUSH int 1 ;
+  code { LAMBDA
+           (pair nat nat)
+           nat
+           { UNPAIR ;
+             PUSH nat 1 ;
+             DUG 2 ;
+             PAIR ;
+             PAIR ;
+             LEFT nat ;
+             LOOP_LEFT
+               { UNPAIR ;
+                 UNPAIR ;
+                 PUSH nat 0 ;
+                 DUP 3 ;
+                 COMPARE ;
+                 EQ ;
+                 IF { DROP 2 ; RIGHT (pair (pair nat nat) nat) }
+                    { PUSH nat 1 ;
+                      PUSH nat 1 ;
+                      DUP 4 ;
+                      AND ;
+                      COMPARE ;
+                      EQ ;
+                      IF { DUP ; DIG 3 ; MUL } { DIG 2 } ;
+                      PUSH nat 1 ;
+                      DIG 3 ;
+                      LSR ;
+                      DUP 3 ;
+                      DIG 3 ;
+                      MUL ;
+                      PAIR ;
+                      PAIR ;
+                      LEFT nat } } } ;
+         PUSH int 1 ;
          PUSH int 10000 ;
          PAIR ;
          PUSH int 1 ;
@@ -211,12 +244,13 @@
                     { PUSH int 1 ; DIG 2 ; SUB ; DUP 3 ; DIG 2 ; MUL ; PAIR ; LEFT int } } ;
              SWAP ;
              DROP } ;
-         DIG 3 ;
+         DIG 4 ;
          UNPAIR ;
          IF_LEFT
            { DIG 2 ;
              DIG 4 ;
-             DROP 2 ;
+             DIG 5 ;
+             DROP 3 ;
              IF_LEFT
                { IF_LEFT
                    { DIG 2 ;
@@ -238,25 +272,25 @@
                          IF {} { PUSH nat 118 ; FAILWITH } ;
                          DUP 2 ;
                          DUP 3 ;
+                         CDR ;
+                         DUP ;
                          CAR ;
                          DUP ;
-                         CDR ;
-                         DUP ;
-                         CDR ;
+                         CAR ;
                          DUP 6 ;
+                         CDR ;
                          CAR ;
-                         CDR ;
-                         CDR ;
-                         CDR ;
+                         CAR ;
+                         CAR ;
                          DUP 6 ;
                          CAR ;
                          GET ;
                          IF_NONE
                            { DIG 5 ;
+                             CDR ;
                              CAR ;
-                             CDR ;
-                             CDR ;
-                             CDR ;
+                             CAR ;
+                             CAR ;
                              DUP 6 ;
                              CDR ;
                              DIG 6 ;
@@ -267,20 +301,20 @@
                              UPDATE }
                            { DROP ;
                              DIG 5 ;
+                             CDR ;
                              CAR ;
-                             CDR ;
-                             CDR ;
-                             CDR ;
+                             CAR ;
+                             CAR ;
                              DUP 6 ;
                              CDR ;
                              SOME ;
                              DIG 6 ;
                              CAR ;
                              UPDATE } ;
-                         UPDATE 2 ;
-                         UPDATE 2 ;
-                         UPDATE 2 ;
                          UPDATE 1 ;
+                         UPDATE 1 ;
+                         UPDATE 1 ;
+                         UPDATE 2 ;
                          NIL operation ;
                          PAIR }
                        { DUP 2 ;
@@ -323,16 +357,16 @@
                                       { DUP 2 ;
                                         CDR ;
                                         CDR ;
+                                        CDR ;
                                         DUP 3 ;
                                         CDR ;
+                                        CDR ;
                                         CAR ;
-                                        CDR ;
-                                        CDR ;
                                         DUP 4 ;
                                         CAR ;
                                         CDR ;
                                         CDR ;
-                                        CAR ;
+                                        CDR ;
                                         DUP 4 ;
                                         CAR ;
                                         DUP ;
@@ -523,18 +557,14 @@
                                         CAR ;
                                         CAR ;
                                         GET 3 ;
-                                        PAIR ;
-                                        DUP 4 ;
-                                        DUP 2 ;
-                                        CAR ;
-                                        DIG 2 ;
-                                        CDR ;
-                                        DUP 2 ;
-                                        DUP 2 ;
+                                        SWAP ;
+                                        DUP 5 ;
+                                        DUP 3 ;
+                                        DUP 3 ;
                                         COMPARE ;
                                         GT ;
-                                        IF { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
-                                           { PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
+                                        IF { DIG 2 ; PUSH string "/" ; CONCAT ; DIG 2 ; CONCAT }
+                                           { SWAP ; PUSH string "/" ; CONCAT ; DIG 2 ; CONCAT } ;
                                         GET ;
                                         IF_NONE
                                           { DUP 4 ;
@@ -628,7 +658,12 @@
                                             CAR ;
                                             CAR ;
                                             GET 3 ;
+                                            PAIR ;
                                             SWAP ;
+                                            DUP 2 ;
+                                            CAR ;
+                                            DIG 2 ;
+                                            CDR ;
                                             DIG 3 ;
                                             DUP 5 ;
                                             GET 8 ;
@@ -666,17 +701,17 @@
                                         DIG 3 ;
                                         CDR ;
                                         DUP ;
-                                        CAR ;
-                                        DUP ;
                                         CDR ;
-                                        DIG 4 ;
-                                        UPDATE 2 ;
-                                        UPDATE 2 ;
+                                        DIG 3 ;
                                         UPDATE 1 ;
                                         UPDATE 2 ;
+                                        UPDATE 2 ;
                                         DUP ;
                                         CDR ;
-                                        DIG 2 ;
+                                        DUP ;
+                                        CDR ;
+                                        DIG 3 ;
+                                        UPDATE 2 ;
                                         UPDATE 2 ;
                                         UPDATE 2 ;
                                         NIL operation ;
@@ -701,6 +736,7 @@
                          DUP 2 ;
                          CDR ;
                          CDR ;
+                         CDR ;
                          SIZE ;
                          DUP 2 ;
                          COMPARE ;
@@ -708,9 +744,8 @@
                          IF { DROP 2 ; PUSH nat 128 ; FAILWITH }
                             { DUP 2 ;
                               CDR ;
+                              CDR ;
                               CAR ;
-                              CDR ;
-                              CDR ;
                               SIZE ;
                               DUP 2 ;
                               COMPARE ;
@@ -724,7 +759,7 @@
                                    DUP ;
                                    CDR ;
                                    DIG 4 ;
-                                   UPDATE 1 ;
+                                   UPDATE 2 ;
                                    UPDATE 2 ;
                                    UPDATE 2 ;
                                    UPDATE 1 ;
@@ -740,9 +775,8 @@
                          UNPAIR ;
                          DUP 5 ;
                          CDR ;
+                         CDR ;
                          CAR ;
-                         CDR ;
-                         CDR ;
                          DUP 3 ;
                          DUP 3 ;
                          COMPARE ;
@@ -753,6 +787,7 @@
                          IF_NONE
                            { DROP 4 ; PUSH nat 117 ; FAILWITH }
                            { DUP 4 ;
+                             CDR ;
                              CDR ;
                              CDR ;
                              DUP 2 ;
@@ -785,18 +820,18 @@
                              CAR ;
                              CAR ;
                              CDR ;
-                             CAR ;
+                             CDR ;
                              DUP 6 ;
                              CAR ;
                              CAR ;
-                             CAR ;
                              CDR ;
+                             CAR ;
                              CDR ;
                              DUP 7 ;
                              CAR ;
                              CAR ;
-                             CAR ;
                              CDR ;
+                             CAR ;
                              CAR ;
                              DUP 7 ;
                              UNPAIR ;
@@ -814,8 +849,8 @@
                                  DUP 5 ;
                                  CAR ;
                                  CAR ;
-                                 CAR ;
                                  CDR ;
+                                 CAR ;
                                  PUSH nat 0 ;
                                  DUP 2 ;
                                  CAR ;
@@ -878,8 +913,8 @@
                                          DUP 5 ;
                                          CAR ;
                                          CAR ;
-                                         CAR ;
                                          CDR ;
+                                         CAR ;
                                          PUSH nat 0 ;
                                          DUP 2 ;
                                          CAR ;
@@ -932,7 +967,7 @@
                                             { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                                          UPDATE ;
                                          UPDATE 1 }
-                                       { DIG 2 ; DIG 5 ; DROP 3 ; DUP 4 ; CAR ; CAR ; CAR ; CDR } }
+                                       { DIG 2 ; DIG 5 ; DROP 3 ; DUP 4 ; CAR ; CAR ; CDR ; CAR } }
                                    { DIG 6 ;
                                      DROP ;
                                      DUP 3 ;
@@ -967,8 +1002,8 @@
                                           DUP 4 ;
                                           CAR ;
                                           CAR ;
-                                          CAR ;
                                           CDR ;
+                                          CAR ;
                                           DUP ;
                                           DUP 2 ;
                                           CDR ;
@@ -994,7 +1029,7 @@
                                              { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                                           UPDATE ;
                                           UPDATE 1 }
-                                        { SWAP ; DROP ; DUP 4 ; CAR ; CAR ; CAR ; CDR } } } ;
+                                        { SWAP ; DROP ; DUP 4 ; CAR ; CAR ; CDR ; CAR } } } ;
                              SWAP ;
                              DUP ;
                              GET 3 ;
@@ -1007,7 +1042,7 @@
                              CDR ;
                              CAR ;
                              CDR ;
-                             CAR ;
+                             CDR ;
                              DUP 5 ;
                              GET ;
                              IF_NONE
@@ -1030,7 +1065,7 @@
                                      CDR ;
                                      CAR ;
                                      CDR ;
-                                     CAR ;
+                                     CDR ;
                                      DIG 7 ;
                                      DIG 7 ;
                                      NONE (map (pair (or unit unit) (or (or unit unit) unit)) nat) ;
@@ -1039,7 +1074,7 @@
                                      SOME ;
                                      DUP 11 ;
                                      UPDATE ;
-                                     UPDATE 1 ;
+                                     UPDATE 2 ;
                                      UPDATE 2 ;
                                      UPDATE 1 ;
                                      UPDATE 2 ;
@@ -1139,7 +1174,7 @@
                                  DUP ;
                                  CAR ;
                                  DUP ;
-                                 CAR ;
+                                 CDR ;
                                  DUP 7 ;
                                  DIG 7 ;
                                  CDR ;
@@ -1149,8 +1184,8 @@
                                  CAR ;
                                  UPDATE ;
                                  UPDATE 2 ;
-                                 UPDATE 2 ;
                                  UPDATE 1 ;
+                                 UPDATE 2 ;
                                  UPDATE 1 ;
                                  UPDATE 1 ;
                                  PUSH mutez 0 ;
@@ -1170,9 +1205,9 @@
                                         EXEC ;
                                         DUP 3 ;
                                         CAR ;
+                                        CDR ;
                                         CAR ;
-                                        CDR ;
-                                        CDR ;
+                                        CAR ;
                                         DIG 2 ;
                                         ADD ;
                                         SWAP ;
@@ -1311,7 +1346,7 @@
                                    DUP ;
                                    CDR ;
                                    DIG 4 ;
-                                   UPDATE 1 ;
+                                   UPDATE 2 ;
                                    UPDATE 2 ;
                                    UPDATE 1 ;
                                    UPDATE 1 ;
@@ -1336,13 +1371,13 @@
                          DIG 2 ;
                          CAR ;
                          DUP ;
-                         CAR ;
-                         DUP ;
                          CDR ;
+                         DUP ;
+                         CAR ;
                          DIG 4 ;
-                         UPDATE 2 ;
-                         UPDATE 2 ;
                          UPDATE 1 ;
+                         UPDATE 1 ;
+                         UPDATE 2 ;
                          UPDATE 1 }
                        { DUP 2 ;
                          CAR ;
@@ -1360,9 +1395,8 @@
                          IF {} { PUSH nat 118 ; FAILWITH } ;
                          DUP 2 ;
                          CDR ;
+                         CDR ;
                          CAR ;
-                         CDR ;
-                         CDR ;
                          DUP 2 ;
                          CAR ;
                          GET ;
@@ -1377,31 +1411,27 @@
                          DUP 4 ;
                          CDR ;
                          DUP ;
-                         CAR ;
-                         DUP ;
-                         CDR ;
-                         DIG 6 ;
-                         CDR ;
-                         CAR ;
-                         CDR ;
                          CDR ;
                          DIG 5 ;
-                         DUP 7 ;
+                         CDR ;
+                         CDR ;
+                         CAR ;
+                         DIG 4 ;
+                         DUP 6 ;
                          GET 3 ;
                          UPDATE 3 ;
-                         DUP 7 ;
+                         DUP 6 ;
                          GET 5 ;
                          UPDATE 5 ;
-                         DUP 7 ;
+                         DUP 6 ;
                          GET 6 ;
                          UPDATE 7 ;
                          SOME ;
-                         DIG 6 ;
+                         DIG 5 ;
                          CAR ;
                          UPDATE ;
-                         UPDATE 2 ;
-                         UPDATE 2 ;
                          UPDATE 1 ;
+                         UPDATE 2 ;
                          UPDATE 2 } ;
                      NIL operation ;
                      PAIR } } }
@@ -1409,7 +1439,8 @@
                { DIG 2 ;
                  DIG 3 ;
                  DIG 4 ;
-                 DROP 3 ;
+                 DIG 5 ;
+                 DROP 4 ;
                  IF_LEFT
                    { IF_LEFT
                        { DUP 2 ;
@@ -1442,10 +1473,10 @@
                                    DUP ;
                                    CAR ;
                                    DUP ;
-                                   CAR ;
+                                   CDR ;
                                    DIG 4 ;
-                                   UPDATE 2 ;
                                    UPDATE 1 ;
+                                   UPDATE 2 ;
                                    UPDATE 1 ;
                                    UPDATE 2 ;
                                    NIL operation ;
@@ -1477,9 +1508,8 @@
                          NOW ;
                          DUP 4 ;
                          CDR ;
+                         CDR ;
                          CAR ;
-                         CDR ;
-                         CDR ;
                          DUP 3 ;
                          UNPAIR ;
                          DUP ;
@@ -1494,9 +1524,9 @@
                          IF { DROP 4 ; PUSH nat 125 ; FAILWITH }
                             { DUP 4 ;
                               CAR ;
+                              CDR ;
                               CAR ;
-                              CDR ;
-                              CDR ;
+                              CAR ;
                               AMOUNT ;
                               DUP 2 ;
                               DUP 2 ;
@@ -1510,18 +1540,18 @@
                                         CAR ;
                                         CAR ;
                                         CDR ;
-                                        CAR ;
+                                        CDR ;
                                         DUP 5 ;
                                         CAR ;
                                         CAR ;
-                                        CAR ;
                                         CDR ;
+                                        CAR ;
                                         CDR ;
                                         DUP 6 ;
                                         CAR ;
                                         CAR ;
-                                        CAR ;
                                         CDR ;
+                                        CAR ;
                                         CAR ;
                                         DUP 5 ;
                                         UNPAIR ;
@@ -1539,8 +1569,8 @@
                                             DUP 4 ;
                                             CAR ;
                                             CAR ;
-                                            CAR ;
                                             CDR ;
+                                            CAR ;
                                             PUSH nat 0 ;
                                             DUP 2 ;
                                             CAR ;
@@ -1603,8 +1633,8 @@
                                                     DUP 4 ;
                                                     CAR ;
                                                     CAR ;
-                                                    CAR ;
                                                     CDR ;
+                                                    CAR ;
                                                     PUSH nat 0 ;
                                                     DUP 2 ;
                                                     CAR ;
@@ -1657,7 +1687,7 @@
                                                        { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                                                     UPDATE ;
                                                     UPDATE 1 }
-                                                  { DIG 2 ; DROP 2 ; DUP 4 ; CAR ; CAR ; CAR ; CDR } }
+                                                  { DIG 2 ; DROP 2 ; DUP 4 ; CAR ; CAR ; CDR ; CAR } }
                                               { DUP 3 ;
                                                 INT ;
                                                 ADD ;
@@ -1690,8 +1720,8 @@
                                                      DUP 4 ;
                                                      CAR ;
                                                      CAR ;
-                                                     CAR ;
                                                      CDR ;
+                                                     CAR ;
                                                      DUP ;
                                                      DUP 2 ;
                                                      CDR ;
@@ -1717,7 +1747,7 @@
                                                         { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                                                      UPDATE ;
                                                      UPDATE 1 }
-                                                   { SWAP ; DROP ; DUP 4 ; CAR ; CAR ; CAR ; CDR } } } ;
+                                                   { SWAP ; DROP ; DUP 4 ; CAR ; CAR ; CDR ; CAR } } } ;
                                         SWAP ;
                                         DUP ;
                                         GET 3 ;
@@ -1732,9 +1762,8 @@
                                              IF { DIG 2 ; DROP }
                                                 { DUP 5 ;
                                                   CDR ;
+                                                  CDR ;
                                                   CAR ;
-                                                  CDR ;
-                                                  CDR ;
                                                   DIG 3 ;
                                                   UNPAIR ;
                                                   DUP ;
@@ -1756,13 +1785,13 @@
                                                   CAR ;
                                                   CAR ;
                                                   CDR ;
-                                                  CAR ;
+                                                  CDR ;
                                                   INT ;
                                                   DUP 6 ;
                                                   CDR ;
                                                   CAR ;
-                                                  CAR ;
                                                   CDR ;
+                                                  CAR ;
                                                   INT ;
                                                   MUL ;
                                                   NOW ;
@@ -1776,10 +1805,10 @@
                                              DUP ;
                                              CAR ;
                                              DUP ;
-                                             CAR ;
+                                             CDR ;
                                              DUP 6 ;
-                                             UPDATE 2 ;
                                              UPDATE 1 ;
+                                             UPDATE 2 ;
                                              UPDATE 1 ;
                                              UPDATE 1 ;
                                              DUP 2 ;
@@ -1788,8 +1817,8 @@
                                              DUP 3 ;
                                              CAR ;
                                              CDR ;
-                                             CAR ;
                                              CDR ;
+                                             CAR ;
                                              ADD ;
                                              DUP 6 ;
                                              GET 5 ;
@@ -1822,6 +1851,7 @@
                                                        IF { UNIT ; RIGHT (or unit unit) } { PUSH nat 107 ; FAILWITH } } } ;
                                              SENDER ;
                                              DUP 6 ;
+                                             CDR ;
                                              CDR ;
                                              CDR ;
                                              DUP 10 ;
@@ -1922,9 +1952,8 @@
                                                           PAIR ;
                                                           DUP 7 ;
                                                           CDR ;
+                                                          CDR ;
                                                           CAR ;
-                                                          CDR ;
-                                                          CDR ;
                                                           DUP 5 ;
                                                           IF_LEFT { DROP ; SWAP } { DROP ; DUP 2 ; CAR ; DIG 2 ; CDR ; PAIR } ;
                                                           UNPAIR ;
@@ -1950,7 +1979,7 @@
                                              CDR ;
                                              CAR ;
                                              CDR ;
-                                             CAR ;
+                                             CDR ;
                                              DUP 2 ;
                                              GET 5 ;
                                              GET ;
@@ -1963,37 +1992,67 @@
                                                  SWAP ;
                                                  COMPARE ;
                                                  LE } ;
-                                             IF { DUP ;
-                                                  GET 5 ;
+                                             IF { DUP 4 ;
+                                                  CAR ;
+                                                  CAR ;
+                                                  CAR ;
+                                                  CDR ;
                                                   DUP 5 ;
                                                   CDR ;
                                                   CAR ;
                                                   CDR ;
+                                                  CDR ;
+                                                  DUP 3 ;
+                                                  GET 5 ;
+                                                  GET ;
+                                                  IF_NONE
+                                                    { DUP ;
+                                                      DUP 5 ;
+                                                      GET ;
+                                                      IF_NONE
+                                                        { PUSH nat 1 ; DUP 5 ; SWAP ; SOME ; SWAP ; UPDATE }
+                                                        { PUSH nat 1 ; ADD ; SOME ; DUP 5 ; UPDATE } }
+                                                    { DUP 5 ;
+                                                      GET ;
+                                                      IF_NONE
+                                                        { DUP ;
+                                                          DUP 5 ;
+                                                          GET ;
+                                                          IF_NONE
+                                                            { PUSH nat 1 ; DUP 5 ; SWAP ; SOME ; SWAP ; UPDATE }
+                                                            { PUSH nat 1 ; ADD ; SOME ; DUP 5 ; UPDATE } }
+                                                        { DROP } } ;
+                                                  DUP 2 ;
+                                                  GET 5 ;
+                                                  DUP 6 ;
+                                                  CDR ;
                                                   CAR ;
+                                                  CDR ;
+                                                  CDR ;
                                                   DUP 2 ;
                                                   GET ;
                                                   IF_NONE
-                                                    { DUP 5 ;
+                                                    { DUP 6 ;
                                                       CDR ;
                                                       CAR ;
                                                       CDR ;
-                                                      CAR ;
+                                                      CDR ;
                                                       EMPTY_MAP nat (map (pair (or unit unit) (or (or unit unit) unit)) nat) ;
                                                       EMPTY_MAP (pair (or unit unit) (or (or unit unit) unit)) nat ;
-                                                      DUP 5 ;
+                                                      DUP 6 ;
                                                       GET 7 ;
                                                       CAR ;
                                                       CDR ;
-                                                      DUP 6 ;
-                                                      GET 11 ;
                                                       DUP 7 ;
+                                                      GET 11 ;
+                                                      DUP 8 ;
                                                       GET 9 ;
                                                       PAIR ;
                                                       SWAP ;
                                                       SOME ;
                                                       SWAP ;
                                                       UPDATE ;
-                                                      DUP 7 ;
+                                                      DUP 8 ;
                                                       SWAP ;
                                                       SOME ;
                                                       SWAP ;
@@ -2004,71 +2063,71 @@
                                                       SWAP ;
                                                       UPDATE }
                                                     { DUP ;
-                                                      DUP 6 ;
+                                                      DUP 7 ;
                                                       GET ;
                                                       IF_NONE
                                                         { EMPTY_MAP (pair (or unit unit) (or (or unit unit) unit)) nat ;
-                                                          DUP 4 ;
+                                                          DUP 5 ;
                                                           GET 7 ;
                                                           CAR ;
                                                           CDR ;
-                                                          DUP 5 ;
-                                                          GET 11 ;
                                                           DUP 6 ;
+                                                          GET 11 ;
+                                                          DUP 7 ;
                                                           GET 9 ;
                                                           PAIR ;
                                                           SWAP ;
                                                           SOME ;
                                                           SWAP ;
                                                           UPDATE ;
-                                                          DUP 6 ;
+                                                          DUP 7 ;
                                                           SWAP ;
                                                           SOME ;
                                                           SWAP ;
                                                           UPDATE }
-                                                        { DUP 4 ;
+                                                        { DUP 5 ;
                                                           GET 11 ;
-                                                          DUP 5 ;
+                                                          DUP 6 ;
                                                           GET 9 ;
                                                           PAIR ;
                                                           DUP 2 ;
                                                           DUP 2 ;
                                                           GET ;
                                                           IF_NONE
-                                                            { SWAP ; DUP 5 ; GET 7 ; CAR ; CDR ; DIG 2 ; SWAP ; SOME ; SWAP ; UPDATE }
-                                                            { DUP 6 ; GET 7 ; CAR ; CDR ; ADD ; DIG 2 ; SWAP ; SOME ; DIG 2 ; UPDATE } ;
+                                                            { SWAP ; DUP 6 ; GET 7 ; CAR ; CDR ; DIG 2 ; SWAP ; SOME ; SWAP ; UPDATE }
+                                                            { DUP 7 ; GET 7 ; CAR ; CDR ; ADD ; DIG 2 ; SWAP ; SOME ; DIG 2 ; UPDATE } ;
                                                           SOME ;
-                                                          DUP 6 ;
+                                                          DUP 7 ;
                                                           UPDATE } ;
-                                                      DUP 6 ;
+                                                      DUP 7 ;
                                                       CDR ;
                                                       CAR ;
                                                       CDR ;
-                                                      CAR ;
+                                                      CDR ;
                                                       SWAP ;
                                                       SOME ;
                                                       DIG 2 ;
                                                       UPDATE } ;
-                                                  DUP 6 ;
+                                                  DUP 7 ;
                                                   GET 5 ;
-                                                  DUP 3 ;
+                                                  DUP 4 ;
                                                   GET 9 ;
                                                   IF_LEFT
                                                     { DROP ;
-                                                      DUP 3 ;
+                                                      DUP 4 ;
                                                       GET 7 ;
                                                       CAR ;
                                                       CDR ;
                                                       DUP 2 ;
                                                       GET 7 ;
                                                       ADD ;
-                                                      DUP 4 ;
+                                                      DUP 5 ;
                                                       GET 11 ;
                                                       IF_LEFT
                                                         { IF_LEFT
                                                             { DROP ;
                                                               DUP 2 ;
-                                                              DUP 5 ;
+                                                              DUP 6 ;
                                                               GET 7 ;
                                                               CAR ;
                                                               CDR ;
@@ -2080,7 +2139,7 @@
                                                               UPDATE 7 }
                                                             { DROP ;
                                                               DUP 2 ;
-                                                              DUP 5 ;
+                                                              DUP 6 ;
                                                               GET 7 ;
                                                               CAR ;
                                                               CDR ;
@@ -2092,7 +2151,7 @@
                                                               UPDATE 7 } }
                                                         { DROP ;
                                                           DUP 2 ;
-                                                          DUP 5 ;
+                                                          DUP 6 ;
                                                           GET 7 ;
                                                           CAR ;
                                                           CDR ;
@@ -2103,20 +2162,20 @@
                                                           SWAP ;
                                                           UPDATE 7 } }
                                                     { DROP ;
-                                                      DUP 3 ;
+                                                      DUP 4 ;
                                                       GET 7 ;
                                                       CAR ;
                                                       CDR ;
                                                       DUP 2 ;
                                                       GET 14 ;
                                                       ADD ;
-                                                      DUP 4 ;
+                                                      DUP 5 ;
                                                       GET 11 ;
                                                       IF_LEFT
                                                         { IF_LEFT
                                                             { DROP ;
                                                               DUP 2 ;
-                                                              DUP 5 ;
+                                                              DUP 6 ;
                                                               GET 7 ;
                                                               CAR ;
                                                               CDR ;
@@ -2128,7 +2187,7 @@
                                                               UPDATE 14 }
                                                             { DROP ;
                                                               DUP 2 ;
-                                                              DUP 5 ;
+                                                              DUP 6 ;
                                                               GET 7 ;
                                                               CAR ;
                                                               CDR ;
@@ -2140,7 +2199,7 @@
                                                               UPDATE 14 } }
                                                         { DROP ;
                                                           DUP 2 ;
-                                                          DUP 5 ;
+                                                          DUP 6 ;
                                                           GET 7 ;
                                                           CAR ;
                                                           CDR ;
@@ -2150,25 +2209,25 @@
                                                           UPDATE 13 ;
                                                           SWAP ;
                                                           UPDATE 14 } } ;
-                                                  DUP 6 ;
-                                                  DIG 6 ;
+                                                  DUP 7 ;
+                                                  DIG 7 ;
                                                   CAR ;
                                                   DUP ;
                                                   CAR ;
                                                   DUP ;
-                                                  CAR ;
-                                                  DUP 11 ;
-                                                  DIG 11 ;
                                                   CDR ;
-                                                  DIG 11 ;
+                                                  DUP 12 ;
+                                                  DIG 12 ;
+                                                  CDR ;
+                                                  DIG 12 ;
                                                   DIG 7 ;
                                                   UPDATE 5 ;
                                                   SOME ;
-                                                  DIG 10 ;
+                                                  DIG 11 ;
                                                   UPDATE ;
                                                   UPDATE 2 ;
-                                                  UPDATE 2 ;
                                                   UPDATE 1 ;
+                                                  UPDATE 2 ;
                                                   UPDATE 1 ;
                                                   UPDATE 1 ;
                                                   DUP ;
@@ -2176,12 +2235,23 @@
                                                   DUP ;
                                                   CDR ;
                                                   DUP ;
+                                                  CDR ;
+                                                  DIG 7 ;
+                                                  UPDATE 1 ;
+                                                  UPDATE 2 ;
+                                                  UPDATE 2 ;
+                                                  UPDATE 1 ;
+                                                  DUP ;
+                                                  CDR ;
+                                                  DUP ;
                                                   CAR ;
-                                                  DIG 6 ;
+                                                  DUP ;
+                                                  CDR ;
+                                                  DIG 4 ;
+                                                  UPDATE 2 ;
                                                   UPDATE 2 ;
                                                   UPDATE 1 ;
                                                   UPDATE 2 ;
-                                                  UPDATE 1 ;
                                                   DUP 3 ;
                                                   GET 7 ;
                                                   CAR ;
@@ -2239,16 +2309,16 @@
                                                                   { DROP 4 ; PUSH nat 108 ; FAILWITH } } } } ;
                                                   DUP 2 ;
                                                   DIG 2 ;
-                                                  CDR ;
+                                                  CAR ;
                                                   DUP ;
                                                   CAR ;
                                                   DUP ;
-                                                  CDR ;
+                                                  CAR ;
                                                   DIG 5 ;
-                                                  UPDATE 1 ;
                                                   UPDATE 2 ;
                                                   UPDATE 1 ;
-                                                  UPDATE 2 ;
+                                                  UPDATE 1 ;
+                                                  UPDATE 1 ;
                                                   NIL operation ;
                                                   DIG 2 ;
                                                   CONS ;
@@ -2272,9 +2342,8 @@
                          IF {} { PUSH nat 118 ; FAILWITH } ;
                          DUP 2 ;
                          CDR ;
+                         CDR ;
                          CAR ;
-                         CDR ;
-                         CDR ;
                          DUP 2 ;
                          GET ;
                          IF_NONE { PUSH nat 117 ; FAILWITH } {} ;
@@ -2282,23 +2351,19 @@
                          DUP 4 ;
                          CDR ;
                          DUP ;
-                         CAR ;
-                         DUP ;
-                         CDR ;
-                         DIG 6 ;
-                         CDR ;
-                         CAR ;
-                         CDR ;
                          CDR ;
                          DIG 5 ;
+                         CDR ;
+                         CDR ;
+                         CAR ;
+                         DIG 4 ;
                          PUSH bool True ;
                          UPDATE 8 ;
                          SOME ;
-                         DIG 6 ;
+                         DIG 5 ;
                          UPDATE ;
-                         UPDATE 2 ;
-                         UPDATE 2 ;
                          UPDATE 1 ;
+                         UPDATE 2 ;
                          UPDATE 2 }
                        { DUP 2 ;
                          CAR ;
@@ -2316,9 +2381,8 @@
                          IF {} { PUSH nat 118 ; FAILWITH } ;
                          DUP 2 ;
                          CDR ;
+                         CDR ;
                          CAR ;
-                         CDR ;
-                         CDR ;
                          DUP 2 ;
                          GET ;
                          IF_NONE { PUSH nat 117 ; FAILWITH } {} ;
@@ -2326,23 +2390,19 @@
                          DUP 4 ;
                          CDR ;
                          DUP ;
-                         CAR ;
-                         DUP ;
-                         CDR ;
-                         DIG 6 ;
-                         CDR ;
-                         CAR ;
-                         CDR ;
                          CDR ;
                          DIG 5 ;
+                         CDR ;
+                         CDR ;
+                         CAR ;
+                         DIG 4 ;
                          PUSH bool False ;
                          UPDATE 8 ;
                          SOME ;
-                         DIG 6 ;
+                         DIG 5 ;
                          UPDATE ;
-                         UPDATE 2 ;
-                         UPDATE 2 ;
                          UPDATE 1 ;
+                         UPDATE 2 ;
                          UPDATE 2 } ;
                      NIL operation ;
                      PAIR } }
@@ -2367,35 +2427,36 @@
                          CAR ;
                          CDR ;
                          CAR ;
-                         CAR ;
+                         CDR ;
                          PAIR ;
                          PAIR ;
                          DUP 4 ;
                          CDR ;
                          CAR ;
                          CDR ;
-                         CAR ;
+                         CDR ;
                          EMPTY_MAP string (pair (pair nat string (option address) nat (option string)) nat) ;
                          DUP 2 ;
                          DUP 6 ;
                          GET ;
                          IF_NONE
-                           { DIG 6 ; DROP ; SWAP }
+                           { DIG 6 ; DIG 7 ; DROP 2 ; SWAP }
                            { DUP 7 ;
                              CAR ;
+                             CDR ;
                              CAR ;
-                             CDR ;
-                             CDR ;
+                             CAR ;
                              DIG 4 ;
                              PAIR ;
                              DUP 7 ;
                              CDR ;
                              CDR ;
+                             CDR ;
                              DUP 8 ;
                              CAR ;
                              CAR ;
-                             CAR ;
                              CDR ;
+                             CAR ;
                              PAIR ;
                              DIG 3 ;
                              DUP 4 ;
@@ -2535,20 +2596,20 @@
                                                             SWAP ;
                                                             GET 3 ;
                                                             INT ;
-                                                            PUSH int 1 ;
-                                                            SWAP ;
-                                                            PAIR ;
                                                             DIG 4 ;
                                                             INT ;
                                                             PUSH int 1 ;
                                                             SWAP ;
                                                             PAIR ;
-                                                            DUP 2 ;
+                                                            PUSH int 1 ;
+                                                            DIG 2 ;
+                                                            PAIR ;
+                                                            DUP ;
                                                             CAR ;
-                                                            DUP 2 ;
+                                                            DUP 3 ;
                                                             CDR ;
                                                             MUL ;
-                                                            DIG 2 ;
+                                                            SWAP ;
                                                             CDR ;
                                                             DUP 3 ;
                                                             CAR ;
@@ -2608,36 +2669,12 @@
                                                                { SWAP } ;
                                                             DUP ;
                                                             CDR ;
-                                                            PUSH nat 1 ;
                                                             PUSH nat 0 ;
                                                             PUSH nat 10 ;
                                                             PAIR ;
-                                                            PAIR ;
-                                                            LEFT nat ;
-                                                            LOOP_LEFT
-                                                              { UNPAIR ;
-                                                                UNPAIR ;
-                                                                PUSH nat 0 ;
-                                                                DUP 3 ;
-                                                                COMPARE ;
-                                                                EQ ;
-                                                                IF { DROP 2 ; RIGHT (pair (pair nat nat) nat) }
-                                                                   { PUSH nat 1 ;
-                                                                     PUSH nat 1 ;
-                                                                     DUP 4 ;
-                                                                     AND ;
-                                                                     COMPARE ;
-                                                                     EQ ;
-                                                                     IF { DUP ; DIG 3 ; MUL } { DIG 2 } ;
-                                                                     PUSH nat 1 ;
-                                                                     DIG 3 ;
-                                                                     LSR ;
-                                                                     DUP 3 ;
-                                                                     DIG 3 ;
-                                                                     MUL ;
-                                                                     PAIR ;
-                                                                     PAIR ;
-                                                                     LEFT nat } } ;
+                                                            DUP 23 ;
+                                                            SWAP ;
+                                                            EXEC ;
                                                             DIG 2 ;
                                                             CAR ;
                                                             MUL ;
@@ -2679,36 +2716,12 @@
                                                                     { SWAP } ;
                                                                  DUP ;
                                                                  CDR ;
-                                                                 PUSH nat 1 ;
                                                                  PUSH nat 0 ;
                                                                  PUSH nat 10 ;
                                                                  PAIR ;
-                                                                 PAIR ;
-                                                                 LEFT nat ;
-                                                                 LOOP_LEFT
-                                                                   { UNPAIR ;
-                                                                     UNPAIR ;
-                                                                     PUSH nat 0 ;
-                                                                     DUP 3 ;
-                                                                     COMPARE ;
-                                                                     EQ ;
-                                                                     IF { DROP 2 ; RIGHT (pair (pair nat nat) nat) }
-                                                                        { PUSH nat 1 ;
-                                                                          PUSH nat 1 ;
-                                                                          DUP 4 ;
-                                                                          AND ;
-                                                                          COMPARE ;
-                                                                          EQ ;
-                                                                          IF { DUP ; DIG 3 ; MUL } { DIG 2 } ;
-                                                                          PUSH nat 1 ;
-                                                                          DIG 3 ;
-                                                                          LSR ;
-                                                                          DUP 3 ;
-                                                                          DIG 3 ;
-                                                                          MUL ;
-                                                                          PAIR ;
-                                                                          PAIR ;
-                                                                          LEFT nat } } ;
+                                                                 DUP 21 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
                                                                  DIG 2 ;
                                                                  CAR ;
                                                                  MUL ;
@@ -2733,20 +2746,20 @@
                                                             SWAP ;
                                                             GET 6 ;
                                                             INT ;
-                                                            PUSH int 1 ;
-                                                            SWAP ;
-                                                            PAIR ;
                                                             DIG 4 ;
                                                             INT ;
                                                             PUSH int 1 ;
                                                             SWAP ;
                                                             PAIR ;
-                                                            DUP 2 ;
+                                                            PUSH int 1 ;
+                                                            DIG 2 ;
+                                                            PAIR ;
+                                                            DUP ;
                                                             CAR ;
-                                                            DUP 2 ;
+                                                            DUP 3 ;
                                                             CDR ;
                                                             MUL ;
-                                                            DIG 2 ;
+                                                            SWAP ;
                                                             CDR ;
                                                             DUP 3 ;
                                                             CAR ;
@@ -2806,36 +2819,12 @@
                                                                { SWAP } ;
                                                             DUP ;
                                                             CDR ;
-                                                            PUSH nat 1 ;
                                                             PUSH nat 0 ;
                                                             PUSH nat 10 ;
                                                             PAIR ;
-                                                            PAIR ;
-                                                            LEFT nat ;
-                                                            LOOP_LEFT
-                                                              { UNPAIR ;
-                                                                UNPAIR ;
-                                                                PUSH nat 0 ;
-                                                                DUP 3 ;
-                                                                COMPARE ;
-                                                                EQ ;
-                                                                IF { DROP 2 ; RIGHT (pair (pair nat nat) nat) }
-                                                                   { PUSH nat 1 ;
-                                                                     PUSH nat 1 ;
-                                                                     DUP 4 ;
-                                                                     AND ;
-                                                                     COMPARE ;
-                                                                     EQ ;
-                                                                     IF { DUP ; DIG 3 ; MUL } { DIG 2 } ;
-                                                                     PUSH nat 1 ;
-                                                                     DIG 3 ;
-                                                                     LSR ;
-                                                                     DUP 3 ;
-                                                                     DIG 3 ;
-                                                                     MUL ;
-                                                                     PAIR ;
-                                                                     PAIR ;
-                                                                     LEFT nat } } ;
+                                                            DUP 23 ;
+                                                            SWAP ;
+                                                            EXEC ;
                                                             DIG 2 ;
                                                             CAR ;
                                                             MUL ;
@@ -2877,36 +2866,12 @@
                                                                     { SWAP } ;
                                                                  DUP ;
                                                                  CDR ;
-                                                                 PUSH nat 1 ;
                                                                  PUSH nat 0 ;
                                                                  PUSH nat 10 ;
                                                                  PAIR ;
-                                                                 PAIR ;
-                                                                 LEFT nat ;
-                                                                 LOOP_LEFT
-                                                                   { UNPAIR ;
-                                                                     UNPAIR ;
-                                                                     PUSH nat 0 ;
-                                                                     DUP 3 ;
-                                                                     COMPARE ;
-                                                                     EQ ;
-                                                                     IF { DROP 2 ; RIGHT (pair (pair nat nat) nat) }
-                                                                        { PUSH nat 1 ;
-                                                                          PUSH nat 1 ;
-                                                                          DUP 4 ;
-                                                                          AND ;
-                                                                          COMPARE ;
-                                                                          EQ ;
-                                                                          IF { DUP ; DIG 3 ; MUL } { DIG 2 } ;
-                                                                          PUSH nat 1 ;
-                                                                          DIG 3 ;
-                                                                          LSR ;
-                                                                          DUP 3 ;
-                                                                          DIG 3 ;
-                                                                          MUL ;
-                                                                          PAIR ;
-                                                                          PAIR ;
-                                                                          LEFT nat } } ;
+                                                                 DUP 21 ;
+                                                                 SWAP ;
+                                                                 EXEC ;
                                                                  DIG 2 ;
                                                                  CAR ;
                                                                  MUL ;
@@ -3002,7 +2967,8 @@
                                     PAIR ;
                                     PAIR } ;
                              DIG 5 ;
-                             DROP ;
+                             DIG 6 ;
+                             DROP 2 ;
                              UNPAIR ;
                              CAR ;
                              UNPAIR ;
@@ -3107,13 +3073,14 @@
                          DUP ;
                          CDR ;
                          DIG 5 ;
-                         UPDATE 1 ;
+                         UPDATE 2 ;
                          UPDATE 2 ;
                          UPDATE 1 ;
                          UPDATE 2 ;
                          SWAP }
                        { DIG 2 ;
-                         DROP ;
+                         DIG 3 ;
+                         DROP 2 ;
                          DUP 2 ;
                          CAR ;
                          CAR ;
@@ -3130,24 +3097,24 @@
                          IF {} { PUSH nat 118 ; FAILWITH } ;
                          DUP 2 ;
                          DUP 3 ;
+                         CDR ;
+                         DUP ;
                          CAR ;
                          DUP ;
-                         CDR ;
-                         DUP ;
-                         CDR ;
+                         CAR ;
                          DIG 5 ;
+                         CDR ;
                          CAR ;
-                         CDR ;
-                         CDR ;
-                         CDR ;
+                         CAR ;
+                         CAR ;
                          DIG 5 ;
                          NONE bytes ;
                          SWAP ;
                          UPDATE ;
-                         UPDATE 2 ;
-                         UPDATE 2 ;
-                         UPDATE 2 ;
                          UPDATE 1 ;
+                         UPDATE 1 ;
+                         UPDATE 1 ;
+                         UPDATE 2 ;
                          NIL operation } ;
                      PAIR }
                    { DIG 3 ;
@@ -3155,7 +3122,8 @@
                      IF_LEFT
                        { DIG 2 ;
                          DIG 3 ;
-                         DROP 2 ;
+                         DIG 4 ;
+                         DROP 3 ;
                          DUP 2 ;
                          CAR ;
                          CAR ;
@@ -3175,9 +3143,8 @@
                          IF {} { PUSH nat 137 ; FAILWITH } ;
                          DUP 2 ;
                          CDR ;
+                         CDR ;
                          CAR ;
-                         CDR ;
-                         CDR ;
                          DUP 2 ;
                          CAR ;
                          DUP ;
@@ -3187,19 +3154,24 @@
                          CAR ;
                          CAR ;
                          GET 3 ;
-                         SWAP ;
-                         DUP 3 ;
-                         DUP 3 ;
-                         DUP 3 ;
+                         PAIR ;
+                         DUP 2 ;
+                         DUP 2 ;
+                         CAR ;
+                         DIG 2 ;
+                         CDR ;
+                         DUP 2 ;
+                         DUP 2 ;
                          COMPARE ;
                          GT ;
-                         IF { DIG 2 ; PUSH string "/" ; CONCAT ; DIG 2 ; CONCAT }
-                            { SWAP ; PUSH string "/" ; CONCAT ; DIG 2 ; CONCAT } ;
+                         IF { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
+                            { PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                          GET ;
                          IF_NONE
                            { DROP 2 ; PUSH nat 117 ; FAILWITH }
                            { DROP ;
                              DUP 3 ;
+                             CDR ;
                              CDR ;
                              CDR ;
                              DIG 2 ;
@@ -3508,17 +3480,17 @@
                          DIG 3 ;
                          CDR ;
                          DUP ;
-                         CAR ;
-                         DUP ;
                          CDR ;
-                         DIG 4 ;
-                         UPDATE 2 ;
-                         UPDATE 2 ;
+                         DIG 3 ;
                          UPDATE 1 ;
                          UPDATE 2 ;
+                         UPDATE 2 ;
                          DUP ;
                          CDR ;
-                         DIG 2 ;
+                         DUP ;
+                         CDR ;
+                         DIG 3 ;
+                         UPDATE 2 ;
                          UPDATE 2 ;
                          UPDATE 2 ;
                          NIL operation ;
@@ -3530,14 +3502,14 @@
                          IF {} { PUSH nat 118 ; FAILWITH } ;
                          DUP 2 ;
                          CDR ;
+                         CDR ;
                          CAR ;
-                         CDR ;
-                         CDR ;
                          DUP 2 ;
                          GET ;
                          IF_NONE
-                           { DROP 4 ; PUSH nat 117 ; FAILWITH }
+                           { DROP 5 ; PUSH nat 117 ; FAILWITH }
                            { DUP 3 ;
+                             CDR ;
                              CDR ;
                              CDR ;
                              DUP 2 ;
@@ -3595,7 +3567,7 @@
                              CDR ;
                              CAR ;
                              CAR ;
-                             CAR ;
+                             CDR ;
                              DUP 5 ;
                              GET ;
                              IF_NONE
@@ -3610,13 +3582,13 @@
                              CAR ;
                              CAR ;
                              CDR ;
-                             CAR ;
+                             CDR ;
                              INT ;
                              DUP 6 ;
                              CDR ;
                              CAR ;
-                             CAR ;
                              CDR ;
+                             CAR ;
                              INT ;
                              DUP 3 ;
                              DUG 2 ;
@@ -3665,17 +3637,17 @@
                                 { INT ; PUSH int 10 ; PAIR ; DUP 7 ; SWAP ; EXEC ; DIG 3 } ;
                              INT ;
                              PUSH int 1 ;
-                             SWAP ;
+                             DIG 2 ;
                              PAIR ;
                              PUSH int 1 ;
                              DIG 2 ;
                              PAIR ;
-                             DUP ;
+                             DUP 2 ;
                              CAR ;
-                             DUP 3 ;
+                             DUP 2 ;
                              CDR ;
                              MUL ;
-                             SWAP ;
+                             DIG 2 ;
                              CDR ;
                              DIG 2 ;
                              CAR ;
@@ -3693,6 +3665,7 @@
                              PAIR ;
                              PAIR 3 ;
                              DUP 3 ;
+                             CDR ;
                              CDR ;
                              CDR ;
                              DUP 2 ;
@@ -3764,7 +3737,7 @@
                              CDR ;
                              CAR ;
                              CAR ;
-                             CAR ;
+                             CDR ;
                              DUP 4 ;
                              DIG 4 ;
                              CDR ;
@@ -3783,7 +3756,7 @@
                                  COMPARE ;
                                  GT ;
                                  IF { DIG 4 ; DUP 6 ; SOME ; DIG 7 ; UPDATE } { DIG 6 ; DROP ; DIG 4 } } ;
-                             UPDATE 1 ;
+                             UPDATE 2 ;
                              UPDATE 1 ;
                              UPDATE 1 ;
                              UPDATE 2 ;
@@ -3796,8 +3769,8 @@
                              DUP 3 ;
                              CAR ;
                              CAR ;
-                             CAR ;
                              CDR ;
+                             CAR ;
                              DIG 2 ;
                              UNPAIR ;
                              IF_LEFT { DROP } { DROP ; DUP ; CAR ; SWAP ; CDR ; PAIR } ;
@@ -3805,7 +3778,7 @@
                              CAR ;
                              CAR ;
                              CDR ;
-                             CAR ;
+                             CDR ;
                              DUP 3 ;
                              CDR ;
                              DUP 4 ;
@@ -3960,7 +3933,7 @@
                                       SWAP } ;
                                  SOME } ;
                              IF_NONE
-                               { SWAP ; DIG 3 ; DIG 4 ; DROP 4 }
+                               { SWAP ; DIG 3 ; DIG 4 ; DIG 5 ; DROP 5 }
                                { DUP ;
                                  GET 3 ;
                                  IF_LEFT
@@ -4156,36 +4129,12 @@
                                          { DUP 3 } ;
                                       DUP ;
                                       CDR ;
-                                      PUSH nat 1 ;
                                       PUSH nat 0 ;
                                       PUSH nat 10 ;
                                       PAIR ;
-                                      PAIR ;
-                                      LEFT nat ;
-                                      LOOP_LEFT
-                                        { UNPAIR ;
-                                          UNPAIR ;
-                                          PUSH nat 0 ;
-                                          DUP 3 ;
-                                          COMPARE ;
-                                          EQ ;
-                                          IF { DROP 2 ; RIGHT (pair (pair nat nat) nat) }
-                                             { PUSH nat 1 ;
-                                               PUSH nat 1 ;
-                                               DUP 4 ;
-                                               AND ;
-                                               COMPARE ;
-                                               EQ ;
-                                               IF { DUP ; DIG 3 ; MUL } { DIG 2 } ;
-                                               PUSH nat 1 ;
-                                               DIG 3 ;
-                                               LSR ;
-                                               DUP 3 ;
-                                               DIG 3 ;
-                                               MUL ;
-                                               PAIR ;
-                                               PAIR ;
-                                               LEFT nat } } ;
+                                      DUP 14 ;
+                                      SWAP ;
+                                      EXEC ;
                                       DIG 2 ;
                                       CAR ;
                                       MUL ;
@@ -4203,36 +4152,12 @@
                                          { DUP 3 } ;
                                       DUP ;
                                       CDR ;
-                                      PUSH nat 1 ;
                                       PUSH nat 0 ;
                                       PUSH nat 10 ;
                                       PAIR ;
-                                      PAIR ;
-                                      LEFT nat ;
-                                      LOOP_LEFT
-                                        { UNPAIR ;
-                                          UNPAIR ;
-                                          PUSH nat 0 ;
-                                          DUP 3 ;
-                                          COMPARE ;
-                                          EQ ;
-                                          IF { DROP 2 ; RIGHT (pair (pair nat nat) nat) }
-                                             { PUSH nat 1 ;
-                                               PUSH nat 1 ;
-                                               DUP 4 ;
-                                               AND ;
-                                               COMPARE ;
-                                               EQ ;
-                                               IF { DUP ; DIG 3 ; MUL } { DIG 2 } ;
-                                               PUSH nat 1 ;
-                                               DIG 3 ;
-                                               LSR ;
-                                               DUP 3 ;
-                                               DIG 3 ;
-                                               MUL ;
-                                               PAIR ;
-                                               PAIR ;
-                                               LEFT nat } } ;
+                                      DUP 15 ;
+                                      SWAP ;
+                                      EXEC ;
                                       DIG 2 ;
                                       CAR ;
                                       MUL ;
@@ -4250,36 +4175,12 @@
                                          { DUP 3 } ;
                                       DUP ;
                                       CDR ;
-                                      PUSH nat 1 ;
                                       PUSH nat 0 ;
                                       PUSH nat 10 ;
                                       PAIR ;
-                                      PAIR ;
-                                      LEFT nat ;
-                                      LOOP_LEFT
-                                        { UNPAIR ;
-                                          UNPAIR ;
-                                          PUSH nat 0 ;
-                                          DUP 3 ;
-                                          COMPARE ;
-                                          EQ ;
-                                          IF { DROP 2 ; RIGHT (pair (pair nat nat) nat) }
-                                             { PUSH nat 1 ;
-                                               PUSH nat 1 ;
-                                               DUP 4 ;
-                                               AND ;
-                                               COMPARE ;
-                                               EQ ;
-                                               IF { DUP ; DIG 3 ; MUL } { DIG 2 } ;
-                                               PUSH nat 1 ;
-                                               DIG 3 ;
-                                               LSR ;
-                                               DUP 3 ;
-                                               DIG 3 ;
-                                               MUL ;
-                                               PAIR ;
-                                               PAIR ;
-                                               LEFT nat } } ;
+                                      DUP 16 ;
+                                      SWAP ;
+                                      EXEC ;
                                       DIG 2 ;
                                       CAR ;
                                       MUL ;
@@ -4466,36 +4367,12 @@
                                          {} ;
                                       DUP ;
                                       CDR ;
-                                      PUSH nat 1 ;
                                       PUSH nat 0 ;
                                       PUSH nat 10 ;
                                       PAIR ;
-                                      PAIR ;
-                                      LEFT nat ;
-                                      LOOP_LEFT
-                                        { UNPAIR ;
-                                          UNPAIR ;
-                                          PUSH nat 0 ;
-                                          DUP 3 ;
-                                          COMPARE ;
-                                          EQ ;
-                                          IF { DROP 2 ; RIGHT (pair (pair nat nat) nat) }
-                                             { PUSH nat 1 ;
-                                               PUSH nat 1 ;
-                                               DUP 4 ;
-                                               AND ;
-                                               COMPARE ;
-                                               EQ ;
-                                               IF { DUP ; DIG 3 ; MUL } { DIG 2 } ;
-                                               PUSH nat 1 ;
-                                               DIG 3 ;
-                                               LSR ;
-                                               DUP 3 ;
-                                               DIG 3 ;
-                                               MUL ;
-                                               PAIR ;
-                                               PAIR ;
-                                               LEFT nat } } ;
+                                      DIG 13 ;
+                                      SWAP ;
+                                      EXEC ;
                                       DIG 2 ;
                                       CAR ;
                                       MUL ;
@@ -4547,22 +4424,22 @@
                                          { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                                       UPDATE ;
                                       UPDATE 1 }
-                                    { DIG 3 ; DIG 4 ; DROP 3 } ;
+                                    { DIG 3 ; DIG 4 ; DIG 5 ; DROP 4 } ;
                                  DUP 2 ;
                                  DIG 2 ;
                                  CAR ;
                                  DUP ;
                                  CAR ;
                                  DUP ;
-                                 CAR ;
+                                 CDR ;
                                  DIG 4 ;
-                                 UPDATE 2 ;
                                  UPDATE 1 ;
+                                 UPDATE 2 ;
                                  UPDATE 1 ;
                                  UPDATE 1 } ;
                              NIL operation ;
                              PAIR } } } } } } ;
-  view "get_fee_in_mutez" unit mutez { CDR ; CAR ; CAR ; CDR ; CDR } ;
+  view "get_fee_in_mutez" unit mutez { CDR ; CAR ; CDR ; CAR ; CAR } ;
   view "get_valid_swaps"
        unit
        (map string
@@ -4571,7 +4448,7 @@
                   (string %oracle_asset_name)
                   (nat %oracle_precision)
                   (bool %is_disabled_for_deposits)))
-       { CDR ; CDR ; CAR ; CDR ; CDR } ;
+       { CDR ; CDR ; CDR ; CAR } ;
   view "get_valid_tokens"
        unit
        (map string
@@ -4580,7 +4457,7 @@
                   (option %address address)
                   (nat %decimals)
                   (option %standard string)))
-       { CDR ; CDR ; CDR } ;
+       { CDR ; CDR ; CDR ; CDR } ;
   view "get_current_batches"
        unit
        (list (pair (nat %batch_number)
@@ -4630,15 +4507,15 @@
          DUP 2 ;
          CAR ;
          CAR ;
-         CAR ;
          CDR ;
+         CAR ;
          CAR ;
          ITER { CDR ;
                 DUP 3 ;
                 CAR ;
                 CAR ;
-                CAR ;
                 CDR ;
+                CAR ;
                 CDR ;
                 SWAP ;
                 GET ;

--- a/batcher/batcher-ghostnet.tz
+++ b/batcher/batcher-ghostnet.tz
@@ -20,15 +20,16 @@
                        (string %oracle_asset_name)
                        (nat %oracle_precision)
                        (bool %is_disabled_for_deposits)))
-                (or (nat %amend_token_and_pair_limit) (address %change_admin_address)))
-            (or (or (nat %change_deposit_time_window) (mutez %change_fee))
-                (or (pair %change_oracle_source_of_pair
+                (or (nat %amend_token_and_pair_limit) (pair %cancel string string)))
+            (or (or (address %change_admin_address) (nat %change_deposit_time_window))
+                (or (mutez %change_fee)
+                    (pair %change_oracle_source_of_pair
                        (string %pair_name)
                        (address %oracle_address)
                        (string %oracle_asset_name)
-                       (nat %oracle_precision))
-                    (nat %change_scale_factor))))
-        (or (or (or (pair %deposit
+                       (nat %oracle_precision)))))
+        (or (or (or (nat %change_scale_factor)
+                    (pair %deposit
                        (pair %swap
                           (pair %from
                              (pair %token
@@ -46,11 +47,10 @@
                              (option %standard string)))
                        (timestamp %created_at)
                        (nat %side)
-                       (nat %tolerance))
-                    (string %disable_swap_pair_for_deposit))
-                (or (string %enable_swap_pair_for_deposit) (unit %redeem)))
-            (or (or (string %remove_metadata)
-                    (pair %remove_token_swap_pair
+                       (nat %tolerance)))
+                (or (string %disable_swap_pair_for_deposit) (string %enable_swap_pair_for_deposit)))
+            (or (or (unit %redeem) (string %remove_metadata))
+                (or (pair %remove_token_swap_pair
                        (pair %swap
                           (pair %from
                              (pair %token
@@ -69,8 +69,8 @@
                        (address %oracle_address)
                        (string %oracle_asset_name)
                        (nat %oracle_precision)
-                       (bool %is_disabled_for_deposits)))
-                (string %tick)))) ;
+                       (bool %is_disabled_for_deposits))
+                    (string %tick))))) ;
   storage
     (pair (pair (pair (pair (address %administrator)
                             (pair %batch_set
@@ -248,13 +248,14 @@
          UNPAIR ;
          IF_LEFT
            { DIG 2 ;
-             DIG 3 ;
              DIG 4 ;
              DIG 5 ;
-             DROP 4 ;
+             DROP 3 ;
              IF_LEFT
                { IF_LEFT
-                   { IF_LEFT
+                   { DIG 2 ;
+                     DROP ;
+                     IF_LEFT
                        { DUP 2 ;
                          CAR ;
                          CAR ;
@@ -556,14 +557,18 @@
                                         CAR ;
                                         CAR ;
                                         GET 3 ;
-                                        SWAP ;
-                                        DUP 5 ;
-                                        DUP 3 ;
-                                        DUP 3 ;
+                                        PAIR ;
+                                        DUP 4 ;
+                                        DUP 2 ;
+                                        CAR ;
+                                        DIG 2 ;
+                                        CDR ;
+                                        DUP 2 ;
+                                        DUP 2 ;
                                         COMPARE ;
                                         GT ;
-                                        IF { DIG 2 ; PUSH string "/" ; CONCAT ; DIG 2 ; CONCAT }
-                                           { SWAP ; PUSH string "/" ; CONCAT ; DIG 2 ; CONCAT } ;
+                                        IF { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
+                                           { PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                                         GET ;
                                         IF_NONE
                                           { DUP 4 ;
@@ -711,7 +716,9 @@
                                         NIL operation ;
                                         PAIR } } } } }
                    { IF_LEFT
-                       { DUP 2 ;
+                       { DIG 2 ;
+                         DROP ;
+                         DUP 2 ;
                          CAR ;
                          CAR ;
                          CAR ;
@@ -757,6 +764,508 @@
                                    UPDATE 1 ;
                                    NIL operation ;
                                    PAIR } } }
+                       { PUSH mutez 1 ;
+                         AMOUNT ;
+                         COMPARE ;
+                         LT ;
+                         IF {} { PUSH nat 118 ; FAILWITH } ;
+                         SENDER ;
+                         DUP 2 ;
+                         UNPAIR ;
+                         DUP 2 ;
+                         DUP 2 ;
+                         COMPARE ;
+                         GT ;
+                         IF { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
+                            { PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
+                         DUP 4 ;
+                         CDR ;
+                         CAR ;
+                         CDR ;
+                         CDR ;
+                         DUP 2 ;
+                         GET ;
+                         IF_NONE
+                           { DROP 5 ; PUSH nat 117 ; FAILWITH }
+                           { DUP 5 ;
+                             CDR ;
+                             CDR ;
+                             DUP 2 ;
+                             CAR ;
+                             DUP 2 ;
+                             DUP 2 ;
+                             CAR ;
+                             GET ;
+                             IF_NONE { PUSH nat 111 ; FAILWITH } {} ;
+                             DUG 2 ;
+                             CDR ;
+                             GET ;
+                             IF_NONE { PUSH nat 111 ; FAILWITH } {} ;
+                             DUP 3 ;
+                             GET 8 ;
+                             DUP 4 ;
+                             GET 7 ;
+                             DUP 5 ;
+                             GET 5 ;
+                             DIG 5 ;
+                             GET 3 ;
+                             DIG 4 ;
+                             PUSH nat 1 ;
+                             DIG 6 ;
+                             PAIR ;
+                             PAIR ;
+                             PAIR 5 ;
+                             DUP 5 ;
+                             CAR ;
+                             CAR ;
+                             CAR ;
+                             CDR ;
+                             CAR ;
+                             DIG 2 ;
+                             GET ;
+                             IF_NONE { PUSH nat 103 ; FAILWITH } {} ;
+                             DUP 5 ;
+                             CDR ;
+                             CAR ;
+                             CDR ;
+                             CAR ;
+                             DUP 4 ;
+                             GET ;
+                             IF_NONE
+                               { DROP 6 ; PUSH nat 139 ; FAILWITH }
+                               { DUP ;
+                                 DUP 3 ;
+                                 GET ;
+                                 IF_NONE
+                                   { DIG 5 ; DROP 2 ; PUSH nat 139 ; FAILWITH }
+                                   { DUP 7 ;
+                                     DUP 8 ;
+                                     CDR ;
+                                     DUP ;
+                                     CAR ;
+                                     DUP ;
+                                     CDR ;
+                                     DIG 10 ;
+                                     CDR ;
+                                     CAR ;
+                                     CDR ;
+                                     CAR ;
+                                     DIG 6 ;
+                                     DUP 8 ;
+                                     NONE (map (pair (or unit unit) (or (or unit unit) unit)) nat) ;
+                                     SWAP ;
+                                     UPDATE ;
+                                     SOME ;
+                                     DUP 10 ;
+                                     UPDATE ;
+                                     UPDATE 1 ;
+                                     UPDATE 2 ;
+                                     UPDATE 1 ;
+                                     UPDATE 2 ;
+                                     SWAP ;
+                                     PAIR } ;
+                                 UNPAIR ;
+                                 NOW ;
+                                 DUP 3 ;
+                                 CAR ;
+                                 CAR ;
+                                 CAR ;
+                                 CDR ;
+                                 DUP 4 ;
+                                 CAR ;
+                                 CAR ;
+                                 CDR ;
+                                 CAR ;
+                                 DUP 2 ;
+                                 CDR ;
+                                 DUP 3 ;
+                                 CAR ;
+                                 DUP 11 ;
+                                 UNPAIR ;
+                                 DUP ;
+                                 DUP 3 ;
+                                 COMPARE ;
+                                 GT ;
+                                 IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
+                                    { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
+                                 GET ;
+                                 IF_NONE { PUSH nat 0 } {} ;
+                                 GET ;
+                                 IF_NONE
+                                   { DROP ;
+                                     PUSH nat 0 ;
+                                     DUP 2 ;
+                                     CAR ;
+                                     ITER { CDR ; DUP 2 ; DUP 2 ; COMPARE ; GT ; IF { SWAP ; DROP } { DROP } } ;
+                                     PUSH nat 1 ;
+                                     ADD ;
+                                     DIG 8 ;
+                                     PUSH nat 0 ;
+                                     PUSH nat 0 ;
+                                     PUSH nat 0 ;
+                                     PUSH nat 0 ;
+                                     PUSH nat 0 ;
+                                     PUSH nat 0 ;
+                                     PUSH nat 0 ;
+                                     PUSH nat 0 ;
+                                     PAIR 8 ;
+                                     DIG 4 ;
+                                     RIGHT
+                                       (or (pair (pair timestamp
+                                                       (pair (pair nat nat nat)
+                                                             (or (or unit unit) unit)
+                                                             (pair nat nat nat nat)
+                                                             (pair (pair string string) (pair int int) timestamp)))
+                                                 (pair (pair string string) (pair int int) timestamp))
+                                           (pair timestamp timestamp)) ;
+                                     DIG 3 ;
+                                     PAIR 4 ;
+                                     DUP 2 ;
+                                     DUP 3 ;
+                                     CDR ;
+                                     DUP 3 ;
+                                     SOME ;
+                                     DUP 4 ;
+                                     CAR ;
+                                     UPDATE ;
+                                     UPDATE 2 ;
+                                     DIG 2 ;
+                                     CAR ;
+                                     DUP 3 ;
+                                     CAR ;
+                                     SOME ;
+                                     DUP 4 ;
+                                     GET 6 ;
+                                     UNPAIR ;
+                                     DUP ;
+                                     DUP 3 ;
+                                     COMPARE ;
+                                     GT ;
+                                     IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
+                                        { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
+                                     UPDATE ;
+                                     UPDATE 1 }
+                                   { DUP ;
+                                     GET 3 ;
+                                     IF_LEFT
+                                       { DIG 2 ;
+                                         DROP ;
+                                         IF_LEFT
+                                           { DROP 2 ;
+                                             PUSH nat 0 ;
+                                             DUP 2 ;
+                                             CAR ;
+                                             ITER { CDR ; DUP 2 ; DUP 2 ; COMPARE ; GT ; IF { SWAP ; DROP } { DROP } } ;
+                                             PUSH nat 1 ;
+                                             ADD ;
+                                             DIG 8 ;
+                                             PUSH nat 0 ;
+                                             PUSH nat 0 ;
+                                             PUSH nat 0 ;
+                                             PUSH nat 0 ;
+                                             PUSH nat 0 ;
+                                             PUSH nat 0 ;
+                                             PUSH nat 0 ;
+                                             PUSH nat 0 ;
+                                             PAIR 8 ;
+                                             DIG 4 ;
+                                             RIGHT
+                                               (or (pair (pair timestamp
+                                                               (pair (pair nat nat nat)
+                                                                     (or (or unit unit) unit)
+                                                                     (pair nat nat nat nat)
+                                                                     (pair (pair string string) (pair int int) timestamp)))
+                                                         (pair (pair string string) (pair int int) timestamp))
+                                                   (pair timestamp timestamp)) ;
+                                             DIG 3 ;
+                                             PAIR 4 ;
+                                             DUP 2 ;
+                                             DUP 3 ;
+                                             CDR ;
+                                             DUP 3 ;
+                                             SOME ;
+                                             DUP 4 ;
+                                             CAR ;
+                                             UPDATE ;
+                                             UPDATE 2 ;
+                                             DIG 2 ;
+                                             CAR ;
+                                             DUP 3 ;
+                                             CAR ;
+                                             SOME ;
+                                             DUP 4 ;
+                                             GET 6 ;
+                                             UNPAIR ;
+                                             DUP ;
+                                             DUP 3 ;
+                                             COMPARE ;
+                                             GT ;
+                                             IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
+                                                { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
+                                             UPDATE ;
+                                             UPDATE 1 }
+                                           { DIG 3 ; DIG 9 ; DROP 3 ; SWAP } }
+                                       { DIG 10 ;
+                                         DROP ;
+                                         DUP 3 ;
+                                         INT ;
+                                         ADD ;
+                                         DIG 4 ;
+                                         COMPARE ;
+                                         GE ;
+                                         IF { DUP ;
+                                              GET 3 ;
+                                              IF_LEFT
+                                                { SWAP ;
+                                                  DIG 2 ;
+                                                  DROP 2 ;
+                                                  IF_LEFT
+                                                    { DROP ; PUSH nat 105 ; FAILWITH }
+                                                    { DROP ; PUSH nat 105 ; FAILWITH } }
+                                                { DIG 2 ;
+                                                  INT ;
+                                                  DUP 2 ;
+                                                  ADD ;
+                                                  PAIR ;
+                                                  RIGHT
+                                                    (pair (pair timestamp
+                                                                (pair (pair nat nat nat)
+                                                                      (or (or unit unit) unit)
+                                                                      (pair nat nat nat nat)
+                                                                      (pair (pair string string) (pair int int) timestamp)))
+                                                          (pair (pair string string) (pair int int) timestamp)) ;
+                                                  LEFT timestamp ;
+                                                  UPDATE 3 } ;
+                                              DUP 2 ;
+                                              DUP 3 ;
+                                              CDR ;
+                                              DUP 3 ;
+                                              SOME ;
+                                              DUP 4 ;
+                                              CAR ;
+                                              UPDATE ;
+                                              UPDATE 2 ;
+                                              DIG 2 ;
+                                              CAR ;
+                                              DUP 3 ;
+                                              CAR ;
+                                              SOME ;
+                                              DUP 4 ;
+                                              GET 6 ;
+                                              UNPAIR ;
+                                              DUP ;
+                                              DUP 3 ;
+                                              COMPARE ;
+                                              GT ;
+                                              IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
+                                                 { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
+                                              UPDATE ;
+                                              UPDATE 1 }
+                                            { SWAP ; DROP ; SWAP } } } ;
+                                 SWAP ;
+                                 DUP ;
+                                 GET 5 ;
+                                 DUP 4 ;
+                                 ITER { UNPAIR ;
+                                        UNPAIR ;
+                                        IF_LEFT
+                                          { DROP ;
+                                            DUP 2 ;
+                                            DUP 4 ;
+                                            GET 7 ;
+                                            SUB ;
+                                            ABS ;
+                                            SWAP ;
+                                            IF_LEFT
+                                              { IF_LEFT
+                                                  { DROP ;
+                                                    DUP 3 ;
+                                                    DIG 2 ;
+                                                    DIG 3 ;
+                                                    GET 3 ;
+                                                    SUB ;
+                                                    ABS ;
+                                                    UPDATE 3 ;
+                                                    SWAP ;
+                                                    UPDATE 7 }
+                                                  { DROP ;
+                                                    DUP 3 ;
+                                                    DIG 2 ;
+                                                    DIG 3 ;
+                                                    CAR ;
+                                                    SUB ;
+                                                    ABS ;
+                                                    UPDATE 1 ;
+                                                    SWAP ;
+                                                    UPDATE 7 } }
+                                              { DROP ;
+                                                DUP 3 ;
+                                                DIG 2 ;
+                                                DIG 3 ;
+                                                GET 5 ;
+                                                SUB ;
+                                                ABS ;
+                                                UPDATE 5 ;
+                                                SWAP ;
+                                                UPDATE 7 } }
+                                          { DROP ;
+                                            DUP 2 ;
+                                            DUP 4 ;
+                                            GET 14 ;
+                                            SUB ;
+                                            ABS ;
+                                            SWAP ;
+                                            IF_LEFT
+                                              { IF_LEFT
+                                                  { DROP ;
+                                                    DUP 3 ;
+                                                    DIG 2 ;
+                                                    DIG 3 ;
+                                                    GET 11 ;
+                                                    SUB ;
+                                                    ABS ;
+                                                    UPDATE 11 ;
+                                                    SWAP ;
+                                                    UPDATE 14 }
+                                                  { DROP ;
+                                                    DUP 3 ;
+                                                    DIG 2 ;
+                                                    DIG 3 ;
+                                                    GET 9 ;
+                                                    SUB ;
+                                                    ABS ;
+                                                    UPDATE 9 ;
+                                                    SWAP ;
+                                                    UPDATE 14 } }
+                                              { DROP ;
+                                                DUP 3 ;
+                                                DIG 2 ;
+                                                DIG 3 ;
+                                                GET 13 ;
+                                                SUB ;
+                                                ABS ;
+                                                UPDATE 13 ;
+                                                SWAP ;
+                                                UPDATE 14 } } } ;
+                                 DUP 5 ;
+                                 DIG 5 ;
+                                 CAR ;
+                                 DUP ;
+                                 CAR ;
+                                 DUP ;
+                                 CAR ;
+                                 DUP 7 ;
+                                 DIG 7 ;
+                                 CDR ;
+                                 DIG 7 ;
+                                 DIG 7 ;
+                                 UPDATE 5 ;
+                                 SOME ;
+                                 DIG 8 ;
+                                 UPDATE ;
+                                 UPDATE 2 ;
+                                 UPDATE 2 ;
+                                 UPDATE 1 ;
+                                 UPDATE 1 ;
+                                 UPDATE 1 ;
+                                 PUSH mutez 0 ;
+                                 EMPTY_MAP string (pair (pair nat string (option address) nat (option string)) nat) ;
+                                 PAIR ;
+                                 DIG 2 ;
+                                 ITER { SWAP ;
+                                        UNPAIR ;
+                                        DIG 2 ;
+                                        UNPAIR ;
+                                        CAR ;
+                                        IF_LEFT { DROP ; DUP 5 ; CAR ; CAR ; CAR } { DROP ; DUP 5 ; CAR ; CDR } ;
+                                        PAIR ;
+                                        PAIR ;
+                                        DUP 6 ;
+                                        SWAP ;
+                                        EXEC ;
+                                        DUP 3 ;
+                                        CAR ;
+                                        CAR ;
+                                        CDR ;
+                                        CDR ;
+                                        DIG 2 ;
+                                        ADD ;
+                                        SWAP ;
+                                        PAIR } ;
+                                 DIG 2 ;
+                                 DIG 4 ;
+                                 DROP 2 ;
+                                 UNPAIR ;
+                                 SELF_ADDRESS ;
+                                 NIL operation ;
+                                 DIG 2 ;
+                                 ITER { CDR ;
+                                        DUP ;
+                                        CAR ;
+                                        GET 5 ;
+                                        IF_NONE
+                                          { DROP ; PUSH nat 109 ; FAILWITH }
+                                          { DUP 2 ;
+                                            CAR ;
+                                            GET 8 ;
+                                            IF_NONE
+                                              { DROP 2 ; PUSH nat 108 ; FAILWITH }
+                                              { PUSH string "FA1.2 token" ;
+                                                DUP 2 ;
+                                                COMPARE ;
+                                                EQ ;
+                                                IF { DROP ;
+                                                     CONTRACT %transfer (pair (address %from) (address %to) (nat %value)) ;
+                                                     IF_NONE { PUSH nat 101 ; FAILWITH } {} ;
+                                                     PUSH mutez 0 ;
+                                                     DIG 2 ;
+                                                     CDR ;
+                                                     DUP 8 ;
+                                                     DUP 6 ;
+                                                     PAIR 3 ;
+                                                     TRANSFER_TOKENS }
+                                                   { PUSH string "FA2 token" ;
+                                                     SWAP ;
+                                                     COMPARE ;
+                                                     EQ ;
+                                                     IF { CONTRACT %transfer
+                                                            (list (pair (address %from_) (list %tx (pair (address %to_) (nat %token_id) (nat %amount))))) ;
+                                                          IF_NONE { PUSH nat 101 ; FAILWITH } {} ;
+                                                          PUSH mutez 0 ;
+                                                          NIL (pair address (list (pair address nat nat))) ;
+                                                          NIL (pair address nat nat) ;
+                                                          DUP 5 ;
+                                                          CDR ;
+                                                          DIG 5 ;
+                                                          CAR ;
+                                                          CAR ;
+                                                          DUP 11 ;
+                                                          PAIR 3 ;
+                                                          CONS ;
+                                                          DUP 6 ;
+                                                          PAIR ;
+                                                          CONS ;
+                                                          TRANSFER_TOKENS }
+                                                        { DROP 2 ; PUSH nat 108 ; FAILWITH } } } } ;
+                                        CONS } ;
+                                 SWAP ;
+                                 DROP ;
+                                 PUSH mutez 0 ;
+                                 DUP 3 ;
+                                 COMPARE ;
+                                 GT ;
+                                 IF { DIG 3 ;
+                                      CONTRACT unit ;
+                                      IF_NONE
+                                        { SWAP ; DROP ; PUSH nat 102 ; FAILWITH }
+                                        { DIG 2 ; UNIT ; TRANSFER_TOKENS } ;
+                                      CONS }
+                                    { SWAP ; DIG 3 ; DROP 2 } ;
+                                 PAIR } } } } }
+               { DIG 2 ;
+                 DROP ;
+                 IF_LEFT
+                   { IF_LEFT
                        { DUP 2 ;
                          CAR ;
                          CAR ;
@@ -784,9 +1293,7 @@
                          UPDATE 1 ;
                          UPDATE 1 ;
                          NIL operation ;
-                         PAIR } } }
-               { IF_LEFT
-                   { IF_LEFT
+                         PAIR }
                        { DUP 2 ;
                          CAR ;
                          CAR ;
@@ -824,7 +1331,8 @@
                                    UPDATE 1 ;
                                    UPDATE 1 ;
                                    NIL operation ;
-                                   PAIR } } }
+                                   PAIR } } } }
+                   { IF_LEFT
                        { DUP 2 ;
                          CAR ;
                          CAR ;
@@ -850,10 +1358,7 @@
                          UPDATE 2 ;
                          UPDATE 2 ;
                          UPDATE 1 ;
-                         UPDATE 1 ;
-                         NIL operation ;
-                         PAIR } }
-                   { IF_LEFT
+                         UPDATE 1 }
                        { DUP 2 ;
                          CAR ;
                          CAR ;
@@ -912,9 +1417,17 @@
                          UPDATE 2 ;
                          UPDATE 2 ;
                          UPDATE 1 ;
-                         UPDATE 2 ;
-                         NIL operation ;
-                         PAIR }
+                         UPDATE 2 } ;
+                     NIL operation ;
+                     PAIR } } }
+           { IF_LEFT
+               { DIG 2 ;
+                 DIG 3 ;
+                 DIG 4 ;
+                 DIG 5 ;
+                 DROP 4 ;
+                 IF_LEFT
+                   { IF_LEFT
                        { DUP 2 ;
                          CAR ;
                          CAR ;
@@ -952,16 +1465,7 @@
                                    UPDATE 1 ;
                                    UPDATE 2 ;
                                    NIL operation ;
-                                   PAIR } } } } } }
-           { IF_LEFT
-               { DIG 2 ;
-                 DIG 4 ;
-                 DROP 2 ;
-                 IF_LEFT
-                   { DIG 2 ;
-                     DIG 3 ;
-                     DROP 2 ;
-                     IF_LEFT
+                                   PAIR } } }
                        { DUP ;
                          GET 5 ;
                          PUSH nat 0 ;
@@ -1023,11 +1527,16 @@
                                         CAR ;
                                         CAR ;
                                         CDR ;
-                                        DUP ;
-                                        CDR ;
-                                        DUP 2 ;
-                                        CAR ;
                                         DUP 5 ;
+                                        CAR ;
+                                        CAR ;
+                                        CDR ;
+                                        CAR ;
+                                        DUP 2 ;
+                                        CDR ;
+                                        DUP 3 ;
+                                        CAR ;
+                                        DUP 6 ;
                                         UNPAIR ;
                                         DUP ;
                                         DUP 3 ;
@@ -1039,7 +1548,8 @@
                                         IF_NONE { PUSH nat 0 } {} ;
                                         GET ;
                                         IF_NONE
-                                          { PUSH nat 0 ;
+                                          { DROP ;
+                                            PUSH nat 0 ;
                                             DUP 2 ;
                                             CAR ;
                                             ITER { CDR ; DUP 2 ; DUP 2 ; COMPARE ; GT ; IF { SWAP ; DROP } { DROP } } ;
@@ -1091,15 +1601,10 @@
                                                { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                                             UPDATE ;
                                             UPDATE 1 }
-                                          { DUP 6 ;
-                                            CAR ;
-                                            CAR ;
-                                            CDR ;
-                                            CAR ;
-                                            DUP 2 ;
+                                          { DUP ;
                                             GET 3 ;
                                             IF_LEFT
-                                              { SWAP ;
+                                              { DIG 2 ;
                                                 DROP ;
                                                 IF_LEFT
                                                   { DROP 2 ;
@@ -1156,13 +1661,13 @@
                                                     UPDATE ;
                                                     UPDATE 1 }
                                                   { DIG 3 ; DROP 2 ; SWAP } }
-                                              { DUP 2 ;
+                                              { DUP 3 ;
                                                 INT ;
                                                 ADD ;
-                                                DIG 5 ;
+                                                DIG 4 ;
                                                 COMPARE ;
                                                 GE ;
-                                                IF { DUP 2 ;
+                                                IF { DUP ;
                                                      GET 3 ;
                                                      IF_LEFT
                                                        { SWAP ;
@@ -1171,7 +1676,7 @@
                                                          IF_LEFT
                                                            { DROP ; PUSH nat 105 ; FAILWITH }
                                                            { DROP ; PUSH nat 105 ; FAILWITH } }
-                                                       { SWAP ;
+                                                       { DIG 2 ;
                                                          INT ;
                                                          DUP 2 ;
                                                          ADD ;
@@ -1210,7 +1715,7 @@
                                                         { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
                                                      UPDATE ;
                                                      UPDATE 1 }
-                                                   { DROP ; SWAP } } } ;
+                                                   { SWAP ; DROP ; SWAP } } } ;
                                         SWAP ;
                                         DUP ;
                                         GET 3 ;
@@ -1284,10 +1789,7 @@
                                              CAR ;
                                              CDR ;
                                              ADD ;
-                                             DUP 3 ;
-                                             CDR ;
-                                             CDR ;
-                                             DUP 7 ;
+                                             DUP 6 ;
                                              GET 5 ;
                                              PUSH nat 0 ;
                                              DUP 2 ;
@@ -1299,7 +1801,7 @@
                                                   COMPARE ;
                                                   EQ ;
                                                   IF { UNIT ; RIGHT unit } { PUSH nat 106 ; FAILWITH } } ;
-                                             DUP 9 ;
+                                             DUP 7 ;
                                              GET 6 ;
                                              PUSH nat 0 ;
                                              DUP 2 ;
@@ -1317,6 +1819,9 @@
                                                        EQ ;
                                                        IF { UNIT ; RIGHT (or unit unit) } { PUSH nat 107 ; FAILWITH } } } ;
                                              SENDER ;
+                                             DUP 6 ;
+                                             CDR ;
+                                             CDR ;
                                              DUP 10 ;
                                              CAR ;
                                              DUP ;
@@ -1324,13 +1829,13 @@
                                              CAR ;
                                              DUP 2 ;
                                              CDR ;
-                                             DUP 7 ;
+                                             DUP 4 ;
                                              DUP 3 ;
                                              GET 3 ;
                                              GET ;
                                              IF_NONE
-                                               { SWAP ; DIG 2 ; DIG 6 ; DROP 4 ; PUSH nat 110 ; FAILWITH }
-                                               { DIG 7 ;
+                                               { DROP 4 ; PUSH nat 110 ; FAILWITH }
+                                               { DIG 4 ;
                                                  DUP 3 ;
                                                  GET 3 ;
                                                  GET ;
@@ -1747,7 +2252,8 @@
                                                   CONS ;
                                                   PAIR }
                                                 { DROP 6 ; PUSH nat 112 ; FAILWITH } }
-                                           { DROP 5 ; PUSH nat 103 ; FAILWITH } } } } }
+                                           { DROP 5 ; PUSH nat 103 ; FAILWITH } } } } } }
+                   { IF_LEFT
                        { DUP 2 ;
                          CAR ;
                          CAR ;
@@ -1791,14 +2297,8 @@
                          UPDATE 2 ;
                          UPDATE 2 ;
                          UPDATE 1 ;
-                         UPDATE 2 ;
-                         NIL operation ;
-                         PAIR } }
-                   { IF_LEFT
-                       { DIG 2 ;
-                         DIG 3 ;
-                         DROP 2 ;
-                         DUP 2 ;
+                         UPDATE 2 }
+                       { DUP 2 ;
                          CAR ;
                          CAR ;
                          CAR ;
@@ -1841,8 +2341,14 @@
                          UPDATE 2 ;
                          UPDATE 2 ;
                          UPDATE 1 ;
-                         UPDATE 2 ;
-                         NIL operation }
+                         UPDATE 2 } ;
+                     NIL operation ;
+                     PAIR } }
+               { IF_LEFT
+                   { DIG 2 ;
+                     DIG 4 ;
+                     DROP 2 ;
+                     IF_LEFT
                        { DROP ;
                          SENDER ;
                          PUSH mutez 1 ;
@@ -1867,32 +2373,29 @@
                          CAR ;
                          CDR ;
                          CAR ;
-                         DUP ;
-                         DUP 5 ;
+                         EMPTY_MAP string (pair (pair nat string (option address) nat (option string)) nat) ;
+                         DUP 2 ;
+                         DUP 6 ;
                          GET ;
                          IF_NONE
-                           { DIG 5 ;
-                             DIG 6 ;
-                             DROP 2 ;
-                             EMPTY_MAP string (pair (pair nat string (option address) nat (option string)) nat) ;
-                             SWAP }
-                           { DUP 6 ;
+                           { DIG 6 ; DIG 7 ; DROP 2 ; SWAP }
+                           { DUP 7 ;
                              CAR ;
                              CAR ;
                              CDR ;
                              CDR ;
-                             DIG 3 ;
+                             DIG 4 ;
                              PAIR ;
-                             DUP 6 ;
-                             CDR ;
-                             CDR ;
                              DUP 7 ;
+                             CDR ;
+                             CDR ;
+                             DUP 8 ;
                              CAR ;
                              CAR ;
                              CAR ;
                              CDR ;
                              PAIR ;
-                             EMPTY_MAP string (pair (pair nat string (option address) nat (option string)) nat) ;
+                             DIG 3 ;
                              DUP 4 ;
                              PAIR ;
                              PAIR ;
@@ -2500,61 +3003,22 @@
                               CONS }
                             { SWAP ; DROP } ;
                          DUP 3 ;
+                         DIG 3 ;
                          CDR ;
+                         DUP ;
                          CAR ;
-                         COMPARE ;
-                         GT ;
-                         IF { DUP 2 ;
-                              CAR ;
-                              CAR ;
-                              CONTRACT unit ;
-                              IF_NONE
-                                { PUSH nat 102 ; FAILWITH }
-                                { DUP 3 ; CDR ; CAR ; UNIT ; TRANSFER_TOKENS } ;
-                              SOME }
-                            { NONE operation } ;
-                         PUSH mutez 0 ;
-                         DUP 4 ;
+                         DUP ;
                          CDR ;
-                         CDR ;
-                         COMPARE ;
-                         GT ;
-                         IF { DUP 3 ;
-                              CAR ;
-                              CDR ;
-                              CONTRACT unit ;
-                              IF_NONE
-                                { DIG 2 ; DROP ; PUSH nat 102 ; FAILWITH }
-                                { DIG 3 ; CDR ; CDR ; UNIT ; TRANSFER_TOKENS } ;
-                              SOME }
-                            { DIG 2 ; DROP ; NONE operation } ;
-                         DUP 5 ;
                          DIG 5 ;
-                         CDR ;
-                         DUP ;
-                         CAR ;
-                         DUP ;
-                         CDR ;
-                         DIG 7 ;
                          UPDATE 1 ;
                          UPDATE 2 ;
                          UPDATE 1 ;
                          UPDATE 2 ;
-                         DIG 2 ;
-                         IF_NONE
-                           { SWAP ;
-                             IF_NONE { SWAP ; DROP ; NIL operation } { DIG 2 ; SWAP ; CONS } }
-                           { DIG 2 ; IF_NONE { DIG 2 } { DIG 3 ; SWAP ; CONS } ; SWAP ; CONS } } ;
-                     PAIR } }
-               { DIG 3 ;
-                 DROP ;
-                 IF_LEFT
-                   { DIG 2 ;
-                     DIG 3 ;
-                     DIG 4 ;
-                     DROP 3 ;
-                     IF_LEFT
-                       { DUP 2 ;
+                         SWAP }
+                       { DIG 2 ;
+                         DIG 3 ;
+                         DROP 2 ;
+                         DUP 2 ;
                          CAR ;
                          CAR ;
                          CAR ;
@@ -2587,8 +3051,17 @@
                          UPDATE 2 ;
                          UPDATE 2 ;
                          UPDATE 2 ;
-                         UPDATE 1 }
-                       { DUP 2 ;
+                         UPDATE 1 ;
+                         NIL operation } ;
+                     PAIR }
+                   { DIG 3 ;
+                     DROP ;
+                     IF_LEFT
+                       { DIG 2 ;
+                         DIG 3 ;
+                         DIG 4 ;
+                         DROP 3 ;
+                         DUP 2 ;
                          CAR ;
                          CAR ;
                          CAR ;
@@ -2619,18 +3092,14 @@
                          CAR ;
                          CAR ;
                          GET 3 ;
-                         PAIR ;
-                         DUP 2 ;
-                         DUP 2 ;
-                         CAR ;
-                         DIG 2 ;
-                         CDR ;
-                         DUP 2 ;
-                         DUP 2 ;
+                         SWAP ;
+                         DUP 3 ;
+                         DUP 3 ;
+                         DUP 3 ;
                          COMPARE ;
                          GT ;
-                         IF { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
-                            { PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
+                         IF { DIG 2 ; PUSH string "/" ; CONCAT ; DIG 2 ; CONCAT }
+                            { SWAP ; PUSH string "/" ; CONCAT ; DIG 2 ; CONCAT } ;
                          GET ;
                          IF_NONE
                            { DROP 2 ; PUSH nat 117 ; FAILWITH }
@@ -2956,958 +3425,966 @@
                          CDR ;
                          DIG 2 ;
                          UPDATE 2 ;
-                         UPDATE 2 } ;
-                     NIL operation ;
-                     PAIR }
-                   { PUSH mutez 1 ;
-                     AMOUNT ;
-                     COMPARE ;
-                     LT ;
-                     IF {} { PUSH nat 118 ; FAILWITH } ;
-                     DUP 2 ;
-                     CDR ;
-                     CAR ;
-                     CDR ;
-                     CDR ;
-                     DUP 2 ;
-                     GET ;
-                     IF_NONE
-                       { DROP 5 ; PUSH nat 117 ; FAILWITH }
-                       { DUP 3 ;
-                         CDR ;
-                         CDR ;
-                         DUP 2 ;
-                         CAR ;
-                         DUP 2 ;
-                         DUP 2 ;
-                         CAR ;
-                         GET ;
-                         IF_NONE { PUSH nat 111 ; FAILWITH } {} ;
-                         DUG 2 ;
-                         CDR ;
-                         GET ;
-                         IF_NONE { PUSH nat 111 ; FAILWITH } {} ;
-                         DUP 3 ;
-                         GET 8 ;
-                         DUP 4 ;
-                         GET 7 ;
-                         DUP 5 ;
-                         GET 5 ;
-                         DIG 5 ;
-                         GET 3 ;
-                         DIG 4 ;
-                         PUSH nat 1 ;
-                         DIG 6 ;
-                         PAIR ;
-                         PAIR ;
-                         PAIR 5 ;
-                         DUP ;
-                         GET 8 ;
-                         DUP 2 ;
-                         GET 7 ;
-                         DUP 3 ;
-                         GET 5 ;
-                         DUP 4 ;
-                         GET 3 ;
-                         DUP 5 ;
-                         CAR ;
-                         DUP ;
-                         CDR ;
-                         GET 3 ;
-                         SWAP ;
-                         CAR ;
-                         CAR ;
-                         GET 3 ;
-                         PAIR ;
-                         PAIR 5 ;
-                         DUP ;
-                         GET 3 ;
-                         SWAP ;
-                         GET 5 ;
-                         VIEW "getPrice" (pair timestamp nat) ;
-                         IF_NONE { PUSH nat 122 ; FAILWITH } {} ;
-                         UNPAIR ;
-                         DUP 5 ;
-                         CDR ;
-                         CAR ;
-                         CAR ;
-                         CAR ;
-                         DUP 5 ;
-                         GET ;
-                         IF_NONE
-                           {}
-                           { DUP 2 ;
-                             SWAP ;
-                             GET 4 ;
-                             COMPARE ;
-                             GE ;
-                             IF { PUSH nat 121 ; FAILWITH } {} } ;
-                         DUP 5 ;
-                         CAR ;
-                         CAR ;
-                         CDR ;
-                         CAR ;
-                         INT ;
-                         DUP 6 ;
-                         CDR ;
-                         CAR ;
-                         CAR ;
-                         CDR ;
-                         INT ;
-                         DUP 3 ;
-                         DUG 2 ;
-                         MUL ;
-                         NOW ;
-                         SUB ;
+                         UPDATE 2 ;
+                         NIL operation ;
+                         PAIR }
+                       { PUSH mutez 1 ;
+                         AMOUNT ;
                          COMPARE ;
                          LT ;
-                         IF {} { PUSH nat 120 ; FAILWITH } ;
-                         DUP 3 ;
-                         CAR ;
-                         DIG 3 ;
-                         GET 7 ;
-                         DUP ;
-                         DUP 3 ;
-                         CAR ;
-                         CAR ;
-                         GET 7 ;
-                         COMPARE ;
-                         GT ;
-                         IF { DUP 2 ;
-                              CAR ;
-                              CAR ;
-                              GET 7 ;
-                              SUB ;
-                              PUSH int 10 ;
-                              PAIR ;
-                              DUP 7 ;
-                              SWAP ;
-                              EXEC ;
-                              DIG 3 ;
-                              MUL ;
-                              ISNAT ;
-                              IF_NONE { PUSH nat 119 ; FAILWITH } {} ;
-                              DUP 2 ;
-                              CAR ;
-                              CAR ;
-                              GET 7 ;
-                              INT ;
-                              PUSH int 10 ;
-                              PAIR ;
-                              DUP 7 ;
-                              SWAP ;
-                              EXEC ;
-                              SWAP }
-                            { INT ; PUSH int 10 ; PAIR ; DUP 7 ; SWAP ; EXEC ; DIG 3 } ;
-                         INT ;
-                         PUSH int 1 ;
-                         DIG 2 ;
-                         PAIR ;
-                         PUSH int 1 ;
-                         DIG 2 ;
-                         PAIR ;
-                         DUP 2 ;
-                         CAR ;
+                         IF {} { PUSH nat 118 ; FAILWITH } ;
                          DUP 2 ;
                          CDR ;
-                         MUL ;
-                         DIG 2 ;
-                         CDR ;
-                         DIG 2 ;
                          CAR ;
-                         MUL ;
-                         PAIR ;
-                         DIG 2 ;
-                         SWAP ;
-                         DUP 3 ;
-                         CDR ;
-                         GET 3 ;
-                         DIG 3 ;
-                         CAR ;
-                         CAR ;
-                         GET 3 ;
-                         PAIR ;
-                         PAIR 3 ;
-                         DUP 3 ;
                          CDR ;
                          CDR ;
                          DUP 2 ;
-                         CAR ;
-                         DUP 2 ;
-                         DUP 2 ;
-                         CAR ;
-                         GET ;
-                         IF_NONE { PUSH nat 111 ; FAILWITH } {} ;
-                         DUG 2 ;
-                         CDR ;
-                         GET ;
-                         IF_NONE { PUSH nat 111 ; FAILWITH } {} ;
-                         SWAP ;
-                         GET 7 ;
-                         SWAP ;
-                         GET 7 ;
-                         SUB ;
-                         DUP ;
-                         ABS ;
-                         INT ;
-                         PUSH int 10 ;
-                         PAIR ;
-                         DIG 5 ;
-                         SWAP ;
-                         EXEC ;
-                         PUSH int 0 ;
-                         DUP 3 ;
-                         COMPARE ;
-                         EQ ;
-                         IF { DROP 2 ; PUSH int 1 ; PUSH int 1 }
-                            { PUSH int 0 ;
-                              DIG 2 ;
-                              COMPARE ;
-                              LT ;
-                              IF { PUSH int 1 ;
-                                   SWAP ;
-                                   PAIR ;
-                                   PUSH int 1 ;
-                                   PUSH int 1 ;
-                                   PAIR ;
-                                   DUP 2 ;
-                                   CAR ;
-                                   DUP 2 ;
-                                   CDR ;
-                                   MUL ;
-                                   DIG 2 ;
-                                   CDR ;
-                                   DIG 2 ;
-                                   CAR ;
-                                   MUL }
-                                 { PUSH int 1 ; SWAP } } ;
-                         PAIR ;
-                         DUP 2 ;
-                         GET 3 ;
-                         DUP 2 ;
-                         CDR ;
-                         DUP 2 ;
-                         CDR ;
-                         MUL ;
-                         DIG 2 ;
-                         CAR ;
-                         DIG 2 ;
-                         CAR ;
-                         MUL ;
-                         PAIR ;
-                         UPDATE 3 ;
-                         DUP 3 ;
-                         CDR ;
-                         CAR ;
-                         CAR ;
-                         CAR ;
-                         DUP 4 ;
-                         DIG 4 ;
-                         CDR ;
-                         DUP ;
-                         CAR ;
-                         DUP ;
-                         CAR ;
-                         DUP 5 ;
-                         DUP 8 ;
                          GET ;
                          IF_NONE
-                           { DIG 4 ; DUP 6 ; DIG 7 ; SWAP ; SOME ; SWAP ; UPDATE }
-                           { GET 4 ;
-                             DUP 7 ;
-                             GET 4 ;
-                             COMPARE ;
-                             GT ;
-                             IF { DIG 4 ; DUP 6 ; SOME ; DIG 7 ; UPDATE } { DIG 6 ; DROP ; DIG 4 } } ;
-                         UPDATE 1 ;
-                         UPDATE 1 ;
-                         UPDATE 1 ;
-                         UPDATE 2 ;
-                         DUP 2 ;
-                         CAR ;
-                         UNIT ;
-                         LEFT unit ;
-                         IF_LEFT { DROP } { DROP ; DUP ; CAR ; SWAP ; CDR ; PAIR } ;
-                         NOW ;
-                         DUP 3 ;
-                         CAR ;
-                         CAR ;
-                         CAR ;
-                         CDR ;
-                         CDR ;
-                         DUP 4 ;
-                         CAR ;
-                         CAR ;
-                         CAR ;
-                         CDR ;
-                         CAR ;
-                         DUP 4 ;
-                         UNPAIR ;
-                         DUP ;
-                         DUP 3 ;
-                         COMPARE ;
-                         GT ;
-                         IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
-                            { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
-                         GET ;
-                         IF_NONE { PUSH nat 0 } {} ;
-                         GET ;
-                         IF_NONE
-                           { SWAP ;
-                             DROP ;
+                           { DROP 5 ; PUSH nat 117 ; FAILWITH }
+                           { DUP 3 ;
+                             CDR ;
+                             CDR ;
                              DUP 2 ;
                              CAR ;
+                             DUP 2 ;
+                             DUP 2 ;
                              CAR ;
-                             CAR ;
+                             GET ;
+                             IF_NONE { PUSH nat 111 ; FAILWITH } {} ;
+                             DUG 2 ;
                              CDR ;
-                             NONE (pair nat
-                                        (or (or (pair (pair timestamp
-                                                            (pair (pair nat nat nat)
-                                                                  (or (or unit unit) unit)
-                                                                  (pair nat nat nat nat)
-                                                                  (pair (pair string string) (pair int int) timestamp)))
-                                                      (pair (pair string string) (pair int int) timestamp))
-                                                (pair timestamp timestamp))
-                                            timestamp)
-                                        (pair nat nat nat nat nat nat nat nat)
-                                        (pair string string)) }
-                           { DUP 4 ;
+                             GET ;
+                             IF_NONE { PUSH nat 111 ; FAILWITH } {} ;
+                             DUP 3 ;
+                             GET 8 ;
+                             DUP 4 ;
+                             GET 7 ;
+                             DUP 5 ;
+                             GET 5 ;
+                             DIG 5 ;
+                             GET 3 ;
+                             DIG 4 ;
+                             PUSH nat 1 ;
+                             DIG 6 ;
+                             PAIR ;
+                             PAIR ;
+                             PAIR 5 ;
+                             DUP ;
+                             GET 8 ;
+                             DUP 2 ;
+                             GET 7 ;
+                             DUP 3 ;
+                             GET 5 ;
+                             DUP 4 ;
+                             GET 3 ;
+                             DUP 5 ;
                              CAR ;
-                             CAR ;
-                             CAR ;
+                             DUP ;
                              CDR ;
+                             GET 3 ;
+                             SWAP ;
+                             CAR ;
+                             CAR ;
+                             GET 3 ;
+                             PAIR ;
+                             PAIR 5 ;
+                             DUP ;
+                             GET 3 ;
+                             SWAP ;
+                             GET 5 ;
+                             VIEW "getPrice" (pair timestamp nat) ;
+                             IF_NONE { PUSH nat 122 ; FAILWITH } {} ;
+                             UNPAIR ;
+                             DUP 5 ;
+                             CDR ;
+                             CAR ;
+                             CAR ;
+                             CAR ;
+                             DUP 5 ;
+                             GET ;
+                             IF_NONE
+                               {}
+                               { DUP 2 ;
+                                 SWAP ;
+                                 GET 4 ;
+                                 COMPARE ;
+                                 GE ;
+                                 IF { PUSH nat 121 ; FAILWITH } {} } ;
                              DUP 5 ;
                              CAR ;
                              CAR ;
                              CDR ;
                              CAR ;
+                             INT ;
+                             DUP 6 ;
+                             CDR ;
+                             CAR ;
+                             CAR ;
+                             CDR ;
+                             INT ;
                              DUP 3 ;
+                             DUG 2 ;
+                             MUL ;
+                             NOW ;
+                             SUB ;
+                             COMPARE ;
+                             LT ;
+                             IF {} { PUSH nat 120 ; FAILWITH } ;
+                             DUP 3 ;
+                             CAR ;
+                             DIG 3 ;
+                             GET 7 ;
+                             DUP ;
+                             DUP 3 ;
+                             CAR ;
+                             CAR ;
+                             GET 7 ;
+                             COMPARE ;
+                             GT ;
+                             IF { DUP 2 ;
+                                  CAR ;
+                                  CAR ;
+                                  GET 7 ;
+                                  SUB ;
+                                  PUSH int 10 ;
+                                  PAIR ;
+                                  DUP 7 ;
+                                  SWAP ;
+                                  EXEC ;
+                                  DIG 3 ;
+                                  MUL ;
+                                  ISNAT ;
+                                  IF_NONE { PUSH nat 119 ; FAILWITH } {} ;
+                                  DUP 2 ;
+                                  CAR ;
+                                  CAR ;
+                                  GET 7 ;
+                                  INT ;
+                                  PUSH int 10 ;
+                                  PAIR ;
+                                  DUP 7 ;
+                                  SWAP ;
+                                  EXEC ;
+                                  SWAP }
+                                { INT ; PUSH int 10 ; PAIR ; DUP 7 ; SWAP ; EXEC ; DIG 3 } ;
+                             INT ;
+                             PUSH int 1 ;
+                             DIG 2 ;
+                             PAIR ;
+                             PUSH int 1 ;
+                             DIG 2 ;
+                             PAIR ;
+                             DUP 2 ;
+                             CAR ;
+                             DUP 2 ;
+                             CDR ;
+                             MUL ;
+                             DIG 2 ;
+                             CDR ;
+                             DIG 2 ;
+                             CAR ;
+                             MUL ;
+                             PAIR ;
+                             DIG 2 ;
+                             SWAP ;
+                             DUP 3 ;
+                             CDR ;
                              GET 3 ;
-                             IF_LEFT
-                               { SWAP ;
-                                 DROP ;
-                                 IF_LEFT
-                                   { DIG 2 ;
-                                     DROP 2 ;
-                                     PUSH nat 0 ;
-                                     DUP 2 ;
-                                     CAR ;
-                                     ITER { CDR ; DUP 2 ; DUP 2 ; COMPARE ; GT ; IF { SWAP ; DROP } { DROP } } ;
-                                     PUSH nat 1 ;
-                                     ADD ;
-                                     DIG 3 ;
-                                     PUSH nat 0 ;
-                                     PUSH nat 0 ;
-                                     PUSH nat 0 ;
-                                     PUSH nat 0 ;
-                                     PUSH nat 0 ;
-                                     PUSH nat 0 ;
-                                     PUSH nat 0 ;
-                                     PUSH nat 0 ;
-                                     PAIR 8 ;
-                                     DUP 5 ;
-                                     RIGHT
-                                       (or (pair (pair timestamp
-                                                       (pair (pair nat nat nat)
-                                                             (or (or unit unit) unit)
-                                                             (pair nat nat nat nat)
-                                                             (pair (pair string string) (pair int int) timestamp)))
-                                                 (pair (pair string string) (pair int int) timestamp))
-                                           (pair timestamp timestamp)) ;
-                                     DIG 3 ;
-                                     PAIR 4 ;
-                                     DUP 2 ;
-                                     DUP 3 ;
-                                     CDR ;
-                                     DUP 3 ;
-                                     SOME ;
-                                     DUP 4 ;
-                                     CAR ;
-                                     UPDATE ;
-                                     UPDATE 2 ;
-                                     DIG 2 ;
-                                     CAR ;
-                                     DUP 3 ;
-                                     CAR ;
-                                     SOME ;
-                                     DUP 4 ;
-                                     GET 6 ;
-                                     UNPAIR ;
-                                     DUP ;
-                                     DUP 3 ;
-                                     COMPARE ;
-                                     GT ;
-                                     IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
-                                        { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
-                                     UPDATE ;
-                                     UPDATE 1 }
-                                   { DIG 4 ; DROP 2 } }
-                               { DIG 5 ;
-                                 DROP ;
-                                 DUP 2 ;
-                                 INT ;
-                                 ADD ;
-                                 DUP 5 ;
+                             DIG 3 ;
+                             CAR ;
+                             CAR ;
+                             GET 3 ;
+                             PAIR ;
+                             PAIR 3 ;
+                             DUP 3 ;
+                             CDR ;
+                             CDR ;
+                             DUP 2 ;
+                             CAR ;
+                             DUP 2 ;
+                             DUP 2 ;
+                             CAR ;
+                             GET ;
+                             IF_NONE { PUSH nat 111 ; FAILWITH } {} ;
+                             DUG 2 ;
+                             CDR ;
+                             GET ;
+                             IF_NONE { PUSH nat 111 ; FAILWITH } {} ;
+                             SWAP ;
+                             GET 7 ;
+                             SWAP ;
+                             GET 7 ;
+                             SUB ;
+                             DUP ;
+                             ABS ;
+                             INT ;
+                             PUSH int 10 ;
+                             PAIR ;
+                             DIG 5 ;
+                             SWAP ;
+                             EXEC ;
+                             PUSH int 0 ;
+                             DUP 3 ;
+                             COMPARE ;
+                             EQ ;
+                             IF { DROP 2 ; PUSH int 1 ; PUSH int 1 }
+                                { PUSH int 0 ;
+                                  DIG 2 ;
+                                  COMPARE ;
+                                  LT ;
+                                  IF { PUSH int 1 ;
+                                       SWAP ;
+                                       PAIR ;
+                                       PUSH int 1 ;
+                                       PUSH int 1 ;
+                                       PAIR ;
+                                       DUP 2 ;
+                                       CAR ;
+                                       DUP 2 ;
+                                       CDR ;
+                                       MUL ;
+                                       DIG 2 ;
+                                       CDR ;
+                                       DIG 2 ;
+                                       CAR ;
+                                       MUL }
+                                     { PUSH int 1 ; SWAP } } ;
+                             PAIR ;
+                             DUP 2 ;
+                             GET 3 ;
+                             DUP 2 ;
+                             CDR ;
+                             DUP 2 ;
+                             CDR ;
+                             MUL ;
+                             DIG 2 ;
+                             CAR ;
+                             DIG 2 ;
+                             CAR ;
+                             MUL ;
+                             PAIR ;
+                             UPDATE 3 ;
+                             DUP 3 ;
+                             CDR ;
+                             CAR ;
+                             CAR ;
+                             CAR ;
+                             DUP 4 ;
+                             DIG 4 ;
+                             CDR ;
+                             DUP ;
+                             CAR ;
+                             DUP ;
+                             CAR ;
+                             DUP 5 ;
+                             DUP 8 ;
+                             GET ;
+                             IF_NONE
+                               { DIG 4 ; DUP 6 ; DIG 7 ; SWAP ; SOME ; SWAP ; UPDATE }
+                               { GET 4 ;
+                                 DUP 7 ;
+                                 GET 4 ;
                                  COMPARE ;
-                                 GE ;
-                                 IF { DUP 3 ;
+                                 GT ;
+                                 IF { DIG 4 ; DUP 6 ; SOME ; DIG 7 ; UPDATE } { DIG 6 ; DROP ; DIG 4 } } ;
+                             UPDATE 1 ;
+                             UPDATE 1 ;
+                             UPDATE 1 ;
+                             UPDATE 2 ;
+                             DUP 2 ;
+                             CAR ;
+                             UNIT ;
+                             LEFT unit ;
+                             IF_LEFT { DROP } { DROP ; DUP ; CAR ; SWAP ; CDR ; PAIR } ;
+                             NOW ;
+                             DUP 3 ;
+                             CAR ;
+                             CAR ;
+                             CDR ;
+                             CAR ;
+                             DUP 4 ;
+                             CAR ;
+                             CAR ;
+                             CAR ;
+                             CDR ;
+                             CDR ;
+                             DUP 5 ;
+                             CAR ;
+                             CAR ;
+                             CAR ;
+                             CDR ;
+                             CAR ;
+                             DUP 5 ;
+                             UNPAIR ;
+                             DUP ;
+                             DUP 3 ;
+                             COMPARE ;
+                             GT ;
+                             IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
+                                { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
+                             GET ;
+                             IF_NONE { PUSH nat 0 } {} ;
+                             GET ;
+                             IF_NONE
+                               { DIG 2 ;
+                                 DROP 2 ;
+                                 DUP 2 ;
+                                 CAR ;
+                                 CAR ;
+                                 CAR ;
+                                 CDR ;
+                                 NONE (pair nat
+                                            (or (or (pair (pair timestamp
+                                                                (pair (pair nat nat nat)
+                                                                      (or (or unit unit) unit)
+                                                                      (pair nat nat nat nat)
+                                                                      (pair (pair string string) (pair int int) timestamp)))
+                                                          (pair (pair string string) (pair int int) timestamp))
+                                                    (pair timestamp timestamp))
+                                                timestamp)
+                                            (pair nat nat nat nat nat nat nat nat)
+                                            (pair string string)) }
+                               { DUP ;
+                                 GET 3 ;
+                                 IF_LEFT
+                                   { IF_LEFT { DROP ; PUSH bool True } { DROP ; PUSH bool False } }
+                                   { DROP ; PUSH bool False } ;
+                                 IF { SWAP ; DIG 3 ; DROP 2 ; DUP 3 ; CAR ; CAR ; CAR ; CDR }
+                                    { DUP 5 ;
+                                      CAR ;
+                                      CAR ;
+                                      CAR ;
+                                      CDR ;
+                                      DUP 2 ;
                                       GET 3 ;
                                       IF_LEFT
-                                        { SWAP ;
-                                          DIG 3 ;
-                                          DROP 2 ;
+                                        { DIG 3 ;
+                                          DROP ;
                                           IF_LEFT
-                                            { DROP ; PUSH nat 105 ; FAILWITH }
-                                            { DROP ; PUSH nat 105 ; FAILWITH } }
-                                        { SWAP ;
-                                          INT ;
-                                          DUP 2 ;
-                                          CAR ;
-                                          ITER { CDR ; DUP 2 ; DUP 2 ; COMPARE ; GT ; IF { SWAP ; DROP } { DROP } } ;
-                                          PUSH nat 1 ;
-                                          ADD ;
-                                          DIG 3 ;
-                                          PUSH nat 0 ;
-                                          PUSH nat 0 ;
-                                          PUSH nat 0 ;
-                                          PUSH nat 0 ;
-                                          PUSH nat 0 ;
-                                          PUSH nat 0 ;
-                                          PUSH nat 0 ;
-                                          PUSH nat 0 ;
-                                          PAIR 8 ;
-                                          DUP 5 ;
-                                          RIGHT
-                                            (pair (pair timestamp
-                                                        (pair (pair nat nat nat)
-                                                              (or (or unit unit) unit)
-                                                              (pair nat nat nat nat)
-                                                              (pair (pair string string) (pair int int) timestamp)))
-                                                  (pair (pair string string) (pair int int) timestamp)) ;
-                                          LEFT timestamp ;
-                                          DIG 2 ;
-                                          SWAP ;
-                                          UPDATE 3 } ;
-                                      DUP 2 ;
-                                      INT ;
-                                      ADD ;
-                                      DUP 5 ;
-                                      COMPARE ;
-                                      GT ;
-                                      IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
-                                         { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
-                                      UPDATE ;
-                                      UPDATE 1 }
-                                    { DROP } } ;
-                             SWAP ;
-                             SOME } ;
-                         IF_NONE
-                           { SWAP ; DIG 3 ; DIG 4 ; DIG 5 ; DROP 5 }
-                           { DUP ;
-                             GET 3 ;
-                             IF_LEFT
-                               { IF_LEFT
-                                   { DIG 3 ; DROP 2 ; PUSH bool False }
-                                   { CAR ; PUSH int 120 ; ADD ; DIG 3 ; COMPARE ; GT } }
-                               { DIG 3 ; DROP 2 ; PUSH bool False } ;
-                             IF { NOW ;
-                                  DUP 2 ;
-                                  GET 5 ;
-                                  DUP ;
-                                  GET 9 ;
-                                  INT ;
-                                  DUP 2 ;
-                                  GET 11 ;
-                                  INT ;
-                                  DUP 3 ;
-                                  GET 13 ;
-                                  INT ;
-                                  DUP 4 ;
-                                  CAR ;
-                                  INT ;
-                                  DUP 5 ;
-                                  GET 3 ;
-                                  INT ;
-                                  DUP 6 ;
-                                  GET 5 ;
-                                  INT ;
-                                  DIG 3 ;
-                                  DIG 4 ;
-                                  DIG 5 ;
-                                  PAIR ;
-                                  PAIR ;
-                                  SWAP ;
-                                  DIG 2 ;
-                                  DIG 3 ;
-                                  PAIR ;
-                                  PAIR ;
-                                  DUP 8 ;
-                                  GET 3 ;
-                                  DUP 2 ;
-                                  CAR ;
-                                  CAR ;
-                                  DUP 4 ;
-                                  UNPAIR ;
-                                  UNPAIR ;
-                                  DUP 5 ;
-                                  DUP 15 ;
-                                  DIG 4 ;
-                                  DIG 4 ;
-                                  DIG 4 ;
-                                  ADD ;
-                                  ADD ;
-                                  PUSH int 1 ;
-                                  SWAP ;
-                                  PAIR ;
-                                  DUP 2 ;
-                                  CDR ;
-                                  DUP 2 ;
-                                  CDR ;
-                                  MUL ;
-                                  DIG 2 ;
-                                  CAR ;
-                                  DIG 2 ;
-                                  CAR ;
-                                  MUL ;
-                                  PAIR ;
-                                  DUP 2 ;
-                                  CAR ;
-                                  DUP 2 ;
-                                  CDR ;
-                                  MUL ;
-                                  DIG 2 ;
-                                  CDR ;
-                                  DIG 2 ;
-                                  CAR ;
-                                  MUL ;
-                                  PAIR ;
-                                  PUSH int 1 ;
-                                  DIG 2 ;
-                                  PAIR ;
-                                  DUP 2 ;
-                                  CAR ;
-                                  DUP 2 ;
-                                  CDR ;
-                                  MUL ;
-                                  DUP 3 ;
-                                  CDR ;
-                                  DUP 3 ;
-                                  CAR ;
-                                  MUL ;
-                                  COMPARE ;
-                                  LE ;
-                                  IF { SWAP ; DROP } { DROP } ;
-                                  DUP 3 ;
-                                  CAR ;
-                                  UNPAIR ;
-                                  DUP 6 ;
-                                  UNPAIR ;
-                                  CDR ;
-                                  DIG 3 ;
-                                  DIG 3 ;
-                                  ADD ;
-                                  DUP 5 ;
-                                  DIG 3 ;
-                                  DIG 3 ;
-                                  ADD ;
-                                  PUSH int 1 ;
-                                  SWAP ;
-                                  PAIR ;
-                                  DUP 2 ;
-                                  CAR ;
-                                  DUP 2 ;
-                                  CDR ;
-                                  MUL ;
-                                  DIG 2 ;
-                                  CDR ;
-                                  DIG 2 ;
-                                  CAR ;
-                                  MUL ;
-                                  PAIR ;
-                                  PUSH int 1 ;
-                                  DIG 2 ;
-                                  PAIR ;
-                                  DUP 2 ;
-                                  CAR ;
-                                  DUP 2 ;
-                                  CDR ;
-                                  MUL ;
-                                  DUP 3 ;
-                                  CDR ;
-                                  DUP 3 ;
-                                  CAR ;
-                                  MUL ;
-                                  COMPARE ;
-                                  LE ;
-                                  IF { SWAP ; DROP } { DROP } ;
-                                  DIG 3 ;
-                                  UNPAIR ;
-                                  UNPAIR ;
-                                  DIG 6 ;
-                                  CDR ;
-                                  DUG 3 ;
-                                  ADD ;
-                                  ADD ;
-                                  DUP 5 ;
-                                  CDR ;
-                                  DUP 13 ;
-                                  CDR ;
-                                  MUL ;
-                                  DIG 5 ;
-                                  CAR ;
-                                  DUP 13 ;
-                                  CAR ;
-                                  MUL ;
-                                  PAIR ;
-                                  PUSH int 1 ;
-                                  DIG 3 ;
-                                  PAIR ;
-                                  DUP 2 ;
-                                  CAR ;
-                                  DUP 2 ;
-                                  CDR ;
-                                  MUL ;
-                                  DIG 2 ;
-                                  CDR ;
-                                  DIG 2 ;
-                                  CAR ;
-                                  MUL ;
-                                  PAIR ;
-                                  PUSH int 1 ;
-                                  DIG 2 ;
-                                  PAIR ;
-                                  DUP 2 ;
-                                  CAR ;
-                                  DUP 2 ;
-                                  CDR ;
-                                  MUL ;
-                                  DUP 3 ;
-                                  CDR ;
-                                  DUP 3 ;
-                                  CAR ;
-                                  MUL ;
-                                  COMPARE ;
-                                  LE ;
-                                  IF { SWAP ; DROP } { DROP } ;
-                                  PUSH int 0 ;
-                                  DUP 4 ;
-                                  CAR ;
-                                  COMPARE ;
-                                  LT ;
-                                  IF { PUSH int -1 ; DUP 4 ; CDR ; MUL ; PUSH int -1 ; DUP 5 ; CAR ; MUL ; PAIR }
-                                     { DUP 3 } ;
-                                  DUP ;
-                                  CDR ;
-                                  PUSH nat 0 ;
-                                  PUSH nat 10 ;
-                                  PAIR ;
-                                  DUP 14 ;
-                                  SWAP ;
-                                  EXEC ;
-                                  DIG 2 ;
-                                  CAR ;
-                                  MUL ;
-                                  EDIV ;
-                                  IF_NONE { PUSH string "DIV by 0" ; FAILWITH } {} ;
-                                  CAR ;
-                                  ISNAT ;
-                                  IF_NONE { PUSH nat 119 ; FAILWITH } {} ;
-                                  PUSH int 0 ;
-                                  DUP 4 ;
-                                  CAR ;
-                                  COMPARE ;
-                                  LT ;
-                                  IF { PUSH int -1 ; DUP 4 ; CDR ; MUL ; PUSH int -1 ; DUP 5 ; CAR ; MUL ; PAIR }
-                                     { DUP 3 } ;
-                                  DUP ;
-                                  CDR ;
-                                  PUSH nat 0 ;
-                                  PUSH nat 10 ;
-                                  PAIR ;
-                                  DUP 15 ;
-                                  SWAP ;
-                                  EXEC ;
-                                  DIG 2 ;
-                                  CAR ;
-                                  MUL ;
-                                  EDIV ;
-                                  IF_NONE { PUSH string "DIV by 0" ; FAILWITH } {} ;
-                                  CAR ;
-                                  ISNAT ;
-                                  IF_NONE { PUSH nat 119 ; FAILWITH } {} ;
-                                  PUSH int 0 ;
-                                  DUP 4 ;
-                                  CAR ;
-                                  COMPARE ;
-                                  LT ;
-                                  IF { PUSH int -1 ; DUP 4 ; CDR ; MUL ; PUSH int -1 ; DUP 5 ; CAR ; MUL ; PAIR }
-                                     { DUP 3 } ;
-                                  DUP ;
-                                  CDR ;
-                                  PUSH nat 0 ;
-                                  PUSH nat 10 ;
-                                  PAIR ;
-                                  DUP 16 ;
-                                  SWAP ;
-                                  EXEC ;
-                                  DIG 2 ;
-                                  CAR ;
-                                  MUL ;
-                                  EDIV ;
-                                  IF_NONE { PUSH string "DIV by 0" ; FAILWITH } {} ;
-                                  CAR ;
-                                  ISNAT ;
-                                  IF_NONE { PUSH nat 119 ; FAILWITH } {} ;
-                                  DUP 4 ;
-                                  CAR ;
-                                  DUP 7 ;
-                                  CDR ;
-                                  MUL ;
-                                  DUP 5 ;
-                                  CDR ;
-                                  DUP 8 ;
-                                  CAR ;
-                                  MUL ;
-                                  COMPARE ;
-                                  LT ;
-                                  NOT ;
-                                  DUP 6 ;
-                                  CAR ;
-                                  DUP 8 ;
-                                  CDR ;
-                                  MUL ;
-                                  DUP 7 ;
-                                  CDR ;
-                                  DUP 9 ;
-                                  CAR ;
-                                  MUL ;
-                                  COMPARE ;
-                                  LT ;
-                                  NOT ;
-                                  AND ;
-                                  IF { DIG 3 ; DIG 4 ; DIG 5 ; DROP 3 ; UNIT ; RIGHT unit ; LEFT unit }
-                                     { DUP 4 ;
-                                       CAR ;
-                                       DUP 6 ;
-                                       CDR ;
-                                       MUL ;
-                                       DIG 4 ;
-                                       CDR ;
-                                       DUP 6 ;
-                                       CAR ;
-                                       MUL ;
-                                       COMPARE ;
-                                       LT ;
-                                       NOT ;
-                                       DUP 6 ;
-                                       CAR ;
-                                       DUP 6 ;
-                                       CDR ;
-                                       MUL ;
-                                       DIG 6 ;
-                                       CDR ;
-                                       DIG 6 ;
-                                       CAR ;
-                                       MUL ;
-                                       COMPARE ;
-                                       LT ;
-                                       NOT ;
-                                       AND ;
-                                       IF { UNIT ; LEFT unit ; LEFT unit } { UNIT ; RIGHT (or unit unit) } } ;
-                                  DUP 10 ;
-                                  PUSH nat 0 ;
-                                  PUSH nat 0 ;
-                                  PUSH nat 0 ;
-                                  PUSH nat 0 ;
-                                  PAIR 4 ;
-                                  DIG 2 ;
-                                  DIG 3 ;
-                                  DIG 4 ;
-                                  DIG 5 ;
-                                  PAIR 3 ;
-                                  PAIR 4 ;
-                                  DUP ;
-                                  GET 3 ;
-                                  IF_LEFT
-                                    { IF_LEFT
-                                        { DROP ;
-                                          DUP 2 ;
-                                          GET 3 ;
-                                          DUP 3 ;
-                                          CAR ;
-                                          ADD ;
-                                          DUP 3 ;
-                                          GET 13 ;
-                                          DIG 3 ;
-                                          GET 11 ;
-                                          ADD ;
-                                          SWAP }
-                                        { DROP ;
-                                          DUP 2 ;
-                                          GET 13 ;
-                                          DUP 3 ;
-                                          GET 11 ;
+                                            { DIG 2 ;
+                                              DROP 2 ;
+                                              PUSH nat 0 ;
+                                              DUP 2 ;
+                                              CAR ;
+                                              ITER { CDR ; DUP 2 ; DUP 2 ; COMPARE ; GT ; IF { SWAP ; DROP } { DROP } } ;
+                                              PUSH nat 1 ;
+                                              ADD ;
+                                              DIG 3 ;
+                                              PUSH nat 0 ;
+                                              PUSH nat 0 ;
+                                              PUSH nat 0 ;
+                                              PUSH nat 0 ;
+                                              PUSH nat 0 ;
+                                              PUSH nat 0 ;
+                                              PUSH nat 0 ;
+                                              PUSH nat 0 ;
+                                              PAIR 8 ;
+                                              DUP 5 ;
+                                              RIGHT
+                                                (or (pair (pair timestamp
+                                                                (pair (pair nat nat nat)
+                                                                      (or (or unit unit) unit)
+                                                                      (pair nat nat nat nat)
+                                                                      (pair (pair string string) (pair int int) timestamp)))
+                                                          (pair (pair string string) (pair int int) timestamp))
+                                                    (pair timestamp timestamp)) ;
+                                              DIG 3 ;
+                                              PAIR 4 ;
+                                              DUP 2 ;
+                                              DUP 3 ;
+                                              CDR ;
+                                              DUP 3 ;
+                                              SOME ;
+                                              DUP 4 ;
+                                              CAR ;
+                                              UPDATE ;
+                                              UPDATE 2 ;
+                                              DIG 2 ;
+                                              CAR ;
+                                              DUP 3 ;
+                                              CAR ;
+                                              SOME ;
+                                              DUP 4 ;
+                                              GET 6 ;
+                                              UNPAIR ;
+                                              DUP ;
+                                              DUP 3 ;
+                                              COMPARE ;
+                                              GT ;
+                                              IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
+                                                 { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
+                                              UPDATE ;
+                                              UPDATE 1 }
+                                            { DIG 4 ; DROP 2 } }
+                                        { DIG 5 ;
+                                          DROP ;
                                           DUP 4 ;
-                                          GET 9 ;
+                                          INT ;
                                           ADD ;
-                                          ADD ;
-                                          DIG 2 ;
-                                          CAR } }
-                                    { DROP ;
+                                          DUP 5 ;
+                                          COMPARE ;
+                                          GE ;
+                                          IF { DUP 2 ;
+                                               GET 3 ;
+                                               IF_LEFT
+                                                 { DIG 2 ;
+                                                   DIG 3 ;
+                                                   DROP 2 ;
+                                                   IF_LEFT
+                                                     { DROP ; PUSH nat 105 ; FAILWITH }
+                                                     { DROP ; PUSH nat 105 ; FAILWITH } }
+                                                 { DIG 3 ;
+                                                   INT ;
+                                                   DUP 2 ;
+                                                   ADD ;
+                                                   PAIR ;
+                                                   RIGHT
+                                                     (pair (pair timestamp
+                                                                 (pair (pair nat nat nat)
+                                                                       (or (or unit unit) unit)
+                                                                       (pair nat nat nat nat)
+                                                                       (pair (pair string string) (pair int int) timestamp)))
+                                                           (pair (pair string string) (pair int int) timestamp)) ;
+                                                   LEFT timestamp ;
+                                                   DIG 2 ;
+                                                   SWAP ;
+                                                   UPDATE 3 } ;
+                                               DUP 2 ;
+                                               DUP 3 ;
+                                               CDR ;
+                                               DUP 3 ;
+                                               SOME ;
+                                               DUP 4 ;
+                                               CAR ;
+                                               UPDATE ;
+                                               UPDATE 2 ;
+                                               DIG 2 ;
+                                               CAR ;
+                                               DUP 3 ;
+                                               CAR ;
+                                               SOME ;
+                                               DUP 4 ;
+                                               GET 6 ;
+                                               UNPAIR ;
+                                               DUP ;
+                                               DUP 3 ;
+                                               COMPARE ;
+                                               GT ;
+                                               IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
+                                                  { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
+                                               UPDATE ;
+                                               UPDATE 1 }
+                                             { DIG 2 ; DROP } } } ;
+                                 SWAP ;
+                                 SOME } ;
+                             IF_NONE
+                               { SWAP ; DIG 3 ; DIG 4 ; DIG 5 ; DROP 5 }
+                               { DUP ;
+                                 GET 3 ;
+                                 IF_LEFT
+                                   { IF_LEFT
+                                       { DIG 3 ; DROP 2 ; PUSH bool False }
+                                       { CAR ; PUSH int 120 ; ADD ; DIG 3 ; COMPARE ; GT } }
+                                   { DIG 3 ; DROP 2 ; PUSH bool False } ;
+                                 IF { NOW ;
                                       DUP 2 ;
                                       GET 5 ;
+                                      DUP ;
+                                      GET 9 ;
+                                      INT ;
+                                      DUP 2 ;
+                                      GET 11 ;
+                                      INT ;
                                       DUP 3 ;
-                                      GET 3 ;
+                                      GET 13 ;
+                                      INT ;
                                       DUP 4 ;
                                       CAR ;
-                                      ADD ;
-                                      ADD ;
+                                      INT ;
+                                      DUP 5 ;
+                                      GET 3 ;
+                                      INT ;
+                                      DUP 6 ;
+                                      GET 5 ;
+                                      INT ;
+                                      DIG 3 ;
+                                      DIG 4 ;
+                                      DIG 5 ;
+                                      PAIR ;
+                                      PAIR ;
+                                      SWAP ;
                                       DIG 2 ;
-                                      GET 13 ;
-                                      SWAP } ;
-                                  DUP 3 ;
-                                  GET 3 ;
-                                  IF_LEFT
-                                    { IF_LEFT
-                                        { DIG 9 ; DROP 2 ; DUP 8 }
+                                      DIG 3 ;
+                                      PAIR ;
+                                      PAIR ;
+                                      DUP 8 ;
+                                      GET 3 ;
+                                      DUP 2 ;
+                                      CAR ;
+                                      CAR ;
+                                      DUP 4 ;
+                                      UNPAIR ;
+                                      UNPAIR ;
+                                      DUP 5 ;
+                                      DUP 15 ;
+                                      DIG 4 ;
+                                      DIG 4 ;
+                                      DIG 4 ;
+                                      ADD ;
+                                      ADD ;
+                                      PUSH int 1 ;
+                                      SWAP ;
+                                      PAIR ;
+                                      DUP 2 ;
+                                      CDR ;
+                                      DUP 2 ;
+                                      CDR ;
+                                      MUL ;
+                                      DIG 2 ;
+                                      CAR ;
+                                      DIG 2 ;
+                                      CAR ;
+                                      MUL ;
+                                      PAIR ;
+                                      DUP 2 ;
+                                      CAR ;
+                                      DUP 2 ;
+                                      CDR ;
+                                      MUL ;
+                                      DIG 2 ;
+                                      CDR ;
+                                      DIG 2 ;
+                                      CAR ;
+                                      MUL ;
+                                      PAIR ;
+                                      PUSH int 1 ;
+                                      DIG 2 ;
+                                      PAIR ;
+                                      DUP 2 ;
+                                      CAR ;
+                                      DUP 2 ;
+                                      CDR ;
+                                      MUL ;
+                                      DUP 3 ;
+                                      CDR ;
+                                      DUP 3 ;
+                                      CAR ;
+                                      MUL ;
+                                      COMPARE ;
+                                      LE ;
+                                      IF { SWAP ; DROP } { DROP } ;
+                                      DUP 3 ;
+                                      CAR ;
+                                      UNPAIR ;
+                                      DUP 6 ;
+                                      UNPAIR ;
+                                      CDR ;
+                                      DIG 3 ;
+                                      DIG 3 ;
+                                      ADD ;
+                                      DUP 5 ;
+                                      DIG 3 ;
+                                      DIG 3 ;
+                                      ADD ;
+                                      PUSH int 1 ;
+                                      SWAP ;
+                                      PAIR ;
+                                      DUP 2 ;
+                                      CAR ;
+                                      DUP 2 ;
+                                      CDR ;
+                                      MUL ;
+                                      DIG 2 ;
+                                      CDR ;
+                                      DIG 2 ;
+                                      CAR ;
+                                      MUL ;
+                                      PAIR ;
+                                      PUSH int 1 ;
+                                      DIG 2 ;
+                                      PAIR ;
+                                      DUP 2 ;
+                                      CAR ;
+                                      DUP 2 ;
+                                      CDR ;
+                                      MUL ;
+                                      DUP 3 ;
+                                      CDR ;
+                                      DUP 3 ;
+                                      CAR ;
+                                      MUL ;
+                                      COMPARE ;
+                                      LE ;
+                                      IF { SWAP ; DROP } { DROP } ;
+                                      DIG 3 ;
+                                      UNPAIR ;
+                                      UNPAIR ;
+                                      DIG 6 ;
+                                      CDR ;
+                                      DUG 3 ;
+                                      ADD ;
+                                      ADD ;
+                                      DUP 5 ;
+                                      CDR ;
+                                      DUP 13 ;
+                                      CDR ;
+                                      MUL ;
+                                      DIG 5 ;
+                                      CAR ;
+                                      DUP 13 ;
+                                      CAR ;
+                                      MUL ;
+                                      PAIR ;
+                                      PUSH int 1 ;
+                                      DIG 3 ;
+                                      PAIR ;
+                                      DUP 2 ;
+                                      CAR ;
+                                      DUP 2 ;
+                                      CDR ;
+                                      MUL ;
+                                      DIG 2 ;
+                                      CDR ;
+                                      DIG 2 ;
+                                      CAR ;
+                                      MUL ;
+                                      PAIR ;
+                                      PUSH int 1 ;
+                                      DIG 2 ;
+                                      PAIR ;
+                                      DUP 2 ;
+                                      CAR ;
+                                      DUP 2 ;
+                                      CDR ;
+                                      MUL ;
+                                      DUP 3 ;
+                                      CDR ;
+                                      DUP 3 ;
+                                      CAR ;
+                                      MUL ;
+                                      COMPARE ;
+                                      LE ;
+                                      IF { SWAP ; DROP } { DROP } ;
+                                      PUSH int 0 ;
+                                      DUP 4 ;
+                                      CAR ;
+                                      COMPARE ;
+                                      LT ;
+                                      IF { PUSH int -1 ; DUP 4 ; CDR ; MUL ; PUSH int -1 ; DUP 5 ; CAR ; MUL ; PAIR }
+                                         { DUP 3 } ;
+                                      DUP ;
+                                      CDR ;
+                                      PUSH nat 0 ;
+                                      PUSH nat 10 ;
+                                      PAIR ;
+                                      DUP 14 ;
+                                      SWAP ;
+                                      EXEC ;
+                                      DIG 2 ;
+                                      CAR ;
+                                      MUL ;
+                                      EDIV ;
+                                      IF_NONE { PUSH string "DIV by 0" ; FAILWITH } {} ;
+                                      CAR ;
+                                      ISNAT ;
+                                      IF_NONE { PUSH nat 119 ; FAILWITH } {} ;
+                                      PUSH int 0 ;
+                                      DUP 4 ;
+                                      CAR ;
+                                      COMPARE ;
+                                      LT ;
+                                      IF { PUSH int -1 ; DUP 4 ; CDR ; MUL ; PUSH int -1 ; DUP 5 ; CAR ; MUL ; PAIR }
+                                         { DUP 3 } ;
+                                      DUP ;
+                                      CDR ;
+                                      PUSH nat 0 ;
+                                      PUSH nat 10 ;
+                                      PAIR ;
+                                      DUP 15 ;
+                                      SWAP ;
+                                      EXEC ;
+                                      DIG 2 ;
+                                      CAR ;
+                                      MUL ;
+                                      EDIV ;
+                                      IF_NONE { PUSH string "DIV by 0" ; FAILWITH } {} ;
+                                      CAR ;
+                                      ISNAT ;
+                                      IF_NONE { PUSH nat 119 ; FAILWITH } {} ;
+                                      PUSH int 0 ;
+                                      DUP 4 ;
+                                      CAR ;
+                                      COMPARE ;
+                                      LT ;
+                                      IF { PUSH int -1 ; DUP 4 ; CDR ; MUL ; PUSH int -1 ; DUP 5 ; CAR ; MUL ; PAIR }
+                                         { DUP 3 } ;
+                                      DUP ;
+                                      CDR ;
+                                      PUSH nat 0 ;
+                                      PUSH nat 10 ;
+                                      PAIR ;
+                                      DUP 16 ;
+                                      SWAP ;
+                                      EXEC ;
+                                      DIG 2 ;
+                                      CAR ;
+                                      MUL ;
+                                      EDIV ;
+                                      IF_NONE { PUSH string "DIV by 0" ; FAILWITH } {} ;
+                                      CAR ;
+                                      ISNAT ;
+                                      IF_NONE { PUSH nat 119 ; FAILWITH } {} ;
+                                      DUP 4 ;
+                                      CAR ;
+                                      DUP 7 ;
+                                      CDR ;
+                                      MUL ;
+                                      DUP 5 ;
+                                      CDR ;
+                                      DUP 8 ;
+                                      CAR ;
+                                      MUL ;
+                                      COMPARE ;
+                                      LT ;
+                                      NOT ;
+                                      DUP 6 ;
+                                      CAR ;
+                                      DUP 8 ;
+                                      CDR ;
+                                      MUL ;
+                                      DUP 7 ;
+                                      CDR ;
+                                      DUP 9 ;
+                                      CAR ;
+                                      MUL ;
+                                      COMPARE ;
+                                      LT ;
+                                      NOT ;
+                                      AND ;
+                                      IF { DIG 3 ; DIG 4 ; DIG 5 ; DROP 3 ; UNIT ; RIGHT unit ; LEFT unit }
+                                         { DUP 4 ;
+                                           CAR ;
+                                           DUP 6 ;
+                                           CDR ;
+                                           MUL ;
+                                           DIG 4 ;
+                                           CDR ;
+                                           DUP 6 ;
+                                           CAR ;
+                                           MUL ;
+                                           COMPARE ;
+                                           LT ;
+                                           NOT ;
+                                           DUP 6 ;
+                                           CAR ;
+                                           DUP 6 ;
+                                           CDR ;
+                                           MUL ;
+                                           DIG 6 ;
+                                           CDR ;
+                                           DIG 6 ;
+                                           CAR ;
+                                           MUL ;
+                                           COMPARE ;
+                                           LT ;
+                                           NOT ;
+                                           AND ;
+                                           IF { UNIT ; LEFT unit ; LEFT unit } { UNIT ; RIGHT (or unit unit) } } ;
+                                      DUP 10 ;
+                                      PUSH nat 0 ;
+                                      PUSH nat 0 ;
+                                      PUSH nat 0 ;
+                                      PUSH nat 0 ;
+                                      PAIR 4 ;
+                                      DIG 2 ;
+                                      DIG 3 ;
+                                      DIG 4 ;
+                                      DIG 5 ;
+                                      PAIR 3 ;
+                                      PAIR 4 ;
+                                      DUP ;
+                                      GET 3 ;
+                                      IF_LEFT
+                                        { IF_LEFT
+                                            { DROP ;
+                                              DUP 2 ;
+                                              GET 3 ;
+                                              DUP 3 ;
+                                              CAR ;
+                                              ADD ;
+                                              DUP 3 ;
+                                              GET 13 ;
+                                              DIG 3 ;
+                                              GET 11 ;
+                                              ADD ;
+                                              SWAP }
+                                            { DROP ;
+                                              DUP 2 ;
+                                              GET 13 ;
+                                              DUP 3 ;
+                                              GET 11 ;
+                                              DUP 4 ;
+                                              GET 9 ;
+                                              ADD ;
+                                              ADD ;
+                                              DIG 2 ;
+                                              CAR } }
+                                        { DROP ;
+                                          DUP 2 ;
+                                          GET 5 ;
+                                          DUP 3 ;
+                                          GET 3 ;
+                                          DUP 4 ;
+                                          CAR ;
+                                          ADD ;
+                                          ADD ;
+                                          DIG 2 ;
+                                          GET 13 ;
+                                          SWAP } ;
+                                      DUP 3 ;
+                                      GET 3 ;
+                                      IF_LEFT
+                                        { IF_LEFT
+                                            { DIG 9 ; DROP 2 ; DUP 8 }
+                                            { DROP ;
+                                              DUP 8 ;
+                                              GET 3 ;
+                                              DUP 10 ;
+                                              CAR ;
+                                              DUP 2 ;
+                                              CDR ;
+                                              MUL ;
+                                              DIG 10 ;
+                                              CDR ;
+                                              DIG 2 ;
+                                              CAR ;
+                                              MUL ;
+                                              PAIR ;
+                                              DUP 9 ;
+                                              SWAP ;
+                                              UPDATE 3 } }
                                         { DROP ;
                                           DUP 8 ;
                                           GET 3 ;
                                           DUP 10 ;
-                                          CAR ;
+                                          CDR ;
                                           DUP 2 ;
                                           CDR ;
                                           MUL ;
                                           DIG 10 ;
-                                          CDR ;
+                                          CAR ;
                                           DIG 2 ;
                                           CAR ;
                                           MUL ;
                                           PAIR ;
                                           DUP 9 ;
                                           SWAP ;
-                                          UPDATE 3 } }
-                                    { DROP ;
-                                      DUP 8 ;
+                                          UPDATE 3 } ;
+                                      DUP 4 ;
                                       GET 3 ;
-                                      DUP 10 ;
+                                      IF_LEFT
+                                        { IF_LEFT { DROP ; DUP 4 ; CAR ; GET 3 } { DROP ; DUP 4 ; CAR ; CAR } }
+                                        { DROP ; DUP 4 ; CAR ; GET 4 } ;
+                                      DUP 2 ;
+                                      GET 3 ;
+                                      DUP 2 ;
+                                      INT ;
+                                      PUSH int 1 ;
+                                      SWAP ;
+                                      PAIR ;
+                                      DUP 2 ;
                                       CDR ;
                                       DUP 2 ;
                                       CDR ;
                                       MUL ;
-                                      DIG 10 ;
+                                      DIG 2 ;
                                       CAR ;
                                       DIG 2 ;
                                       CAR ;
                                       MUL ;
                                       PAIR ;
-                                      DUP 9 ;
+                                      PUSH int 0 ;
+                                      DUP 2 ;
+                                      CAR ;
+                                      COMPARE ;
+                                      LT ;
+                                      IF { PUSH int -1 ; DUP 2 ; CDR ; MUL ; PUSH int -1 ; DIG 2 ; CAR ; MUL ; PAIR }
+                                         {} ;
+                                      DUP ;
+                                      CDR ;
+                                      PUSH nat 0 ;
+                                      PUSH nat 10 ;
+                                      PAIR ;
+                                      DIG 13 ;
                                       SWAP ;
-                                      UPDATE 3 } ;
-                                  DUP 4 ;
-                                  GET 3 ;
-                                  IF_LEFT
-                                    { IF_LEFT { DROP ; DUP 4 ; CAR ; GET 3 } { DROP ; DUP 4 ; CAR ; CAR } }
-                                    { DROP ; DUP 4 ; CAR ; GET 4 } ;
-                                  DUP 2 ;
-                                  GET 3 ;
-                                  DUP 2 ;
-                                  INT ;
-                                  PUSH int 1 ;
-                                  SWAP ;
-                                  PAIR ;
-                                  DUP 2 ;
-                                  CDR ;
-                                  DUP 2 ;
-                                  CDR ;
-                                  MUL ;
-                                  DIG 2 ;
-                                  CAR ;
-                                  DIG 2 ;
-                                  CAR ;
-                                  MUL ;
-                                  PAIR ;
-                                  PUSH int 0 ;
-                                  DUP 2 ;
-                                  CAR ;
-                                  COMPARE ;
-                                  LT ;
-                                  IF { PUSH int -1 ; DUP 2 ; CDR ; MUL ; PUSH int -1 ; DIG 2 ; CAR ; MUL ; PAIR }
-                                     {} ;
-                                  DUP ;
-                                  CDR ;
-                                  PUSH nat 0 ;
-                                  PUSH nat 10 ;
-                                  PAIR ;
-                                  DIG 13 ;
-                                  SWAP ;
-                                  EXEC ;
-                                  DIG 2 ;
-                                  CAR ;
-                                  MUL ;
-                                  EDIV ;
-                                  IF_NONE { PUSH string "DIV by 0" ; FAILWITH } {} ;
-                                  CAR ;
-                                  ISNAT ;
-                                  IF_NONE { PUSH nat 119 ; FAILWITH } {} ;
-                                  DIG 5 ;
-                                  DIG 5 ;
-                                  DIG 2 ;
-                                  DIG 5 ;
-                                  DIG 4 ;
-                                  PAIR 4 ;
-                                  UPDATE 5 ;
-                                  SWAP ;
-                                  UPDATE 6 ;
-                                  DIG 2 ;
-                                  DIG 5 ;
-                                  DIG 2 ;
-                                  DIG 3 ;
-                                  PAIR ;
-                                  PAIR ;
-                                  LEFT (pair timestamp timestamp) ;
-                                  LEFT timestamp ;
-                                  UPDATE 3 ;
-                                  DUP 2 ;
-                                  DUP 3 ;
-                                  CDR ;
-                                  DUP 3 ;
-                                  SOME ;
-                                  DUP 4 ;
-                                  CAR ;
-                                  UPDATE ;
-                                  UPDATE 2 ;
-                                  DIG 2 ;
-                                  CAR ;
-                                  DUP 3 ;
-                                  CAR ;
-                                  SOME ;
-                                  DIG 3 ;
-                                  GET 6 ;
-                                  UNPAIR ;
-                                  DUP ;
-                                  DUP 3 ;
-                                  COMPARE ;
-                                  GT ;
-                                  IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
-                                     { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
-                                  UPDATE ;
-                                  UPDATE 1 }
-                                { DIG 3 ; DIG 4 ; DIG 5 ; DROP 4 } ;
-                             DUP 2 ;
-                             DIG 2 ;
-                             CAR ;
-                             DUP ;
-                             CAR ;
-                             DUP ;
-                             CAR ;
-                             DIG 4 ;
-                             UPDATE 2 ;
-                             UPDATE 1 ;
-                             UPDATE 1 ;
-                             UPDATE 1 } ;
-                         NIL operation ;
-                         PAIR } } } } } ;
+                                      EXEC ;
+                                      DIG 2 ;
+                                      CAR ;
+                                      MUL ;
+                                      EDIV ;
+                                      IF_NONE { PUSH string "DIV by 0" ; FAILWITH } {} ;
+                                      CAR ;
+                                      ISNAT ;
+                                      IF_NONE { PUSH nat 119 ; FAILWITH } {} ;
+                                      DIG 5 ;
+                                      DIG 5 ;
+                                      DIG 2 ;
+                                      DIG 5 ;
+                                      DIG 4 ;
+                                      PAIR 4 ;
+                                      UPDATE 5 ;
+                                      SWAP ;
+                                      UPDATE 6 ;
+                                      DIG 2 ;
+                                      DIG 5 ;
+                                      DIG 2 ;
+                                      DIG 3 ;
+                                      PAIR ;
+                                      PAIR ;
+                                      LEFT (pair timestamp timestamp) ;
+                                      LEFT timestamp ;
+                                      UPDATE 3 ;
+                                      DUP 2 ;
+                                      DUP 3 ;
+                                      CDR ;
+                                      DUP 3 ;
+                                      SOME ;
+                                      DUP 4 ;
+                                      CAR ;
+                                      UPDATE ;
+                                      UPDATE 2 ;
+                                      DIG 2 ;
+                                      CAR ;
+                                      DUP 3 ;
+                                      CAR ;
+                                      SOME ;
+                                      DIG 3 ;
+                                      GET 6 ;
+                                      UNPAIR ;
+                                      DUP ;
+                                      DUP 3 ;
+                                      COMPARE ;
+                                      GT ;
+                                      IF { PUSH string "/" ; CONCAT ; SWAP ; CONCAT }
+                                         { SWAP ; PUSH string "/" ; CONCAT ; SWAP ; CONCAT } ;
+                                      UPDATE ;
+                                      UPDATE 1 }
+                                    { DIG 3 ; DIG 4 ; DIG 5 ; DROP 4 } ;
+                                 DUP 2 ;
+                                 DIG 2 ;
+                                 CAR ;
+                                 DUP ;
+                                 CAR ;
+                                 DUP ;
+                                 CAR ;
+                                 DIG 4 ;
+                                 UPDATE 2 ;
+                                 UPDATE 1 ;
+                                 UPDATE 1 ;
+                                 UPDATE 1 } ;
+                             NIL operation ;
+                             PAIR } } } } } } ;
   view "get_fee_in_mutez" unit mutez { CDR ; CAR ; CAR ; CDR ; CDR } ;
   view "get_valid_swaps"
        unit

--- a/batcher/batcher-storage-ghostnet.tz
+++ b/batcher/batcher-storage-ghostnet.tz
@@ -1,13 +1,12 @@
-(Pair (Pair (Pair (Pair "tz1aSL2gjFnfh96Xf1Zp4T36LxbzKuzyvVJ4" {} {}) 600 10000)
-            (Pair "tz1burnburnburnburnburnburnburjAYjjX" 0)
-            10
-            {})
-      (Pair (Pair {} 1)
-            {}
-            { Elt "tzBTC/EURL"
-                  (Pair (Pair "tzBTC" "EURL") "KT1DG2g5DPYWqyHKGpRL579YkYZwJxibwaAZ" "BTC-EUR" 6 False) ;
-              Elt "tzBTC/USDT"
-                  (Pair (Pair "tzBTC" "USDT") "KT1DG2g5DPYWqyHKGpRL579YkYZwJxibwaAZ" "BTC-USDT" 6 False) })
+(Pair (Pair (Pair (Pair "tz1aSL2gjFnfh96Xf1Zp4T36LxbzKuzyvVJ4" {}) (Pair {} {}) 600)
+            (Pair 10000 "tz1burnburnburnburnburnburnburjAYjjX")
+            0
+            10)
+      (Pair (Pair {} {}) 1 {})
+      { Elt "tzBTC/EURL"
+            (Pair (Pair "tzBTC" "EURL") "KT1DG2g5DPYWqyHKGpRL579YkYZwJxibwaAZ" "BTC-EUR" 6 False) ;
+        Elt "tzBTC/USDT"
+            (Pair (Pair "tzBTC" "USDT") "KT1DG2g5DPYWqyHKGpRL579YkYZwJxibwaAZ" "BTC-USDT" 6 False) }
       { Elt "EURL" (Pair 0 "EURL" (Some "KT1UhjCszVyY5dkNUXFGAwdNcVgVe2ZeuPv5") 6 (Some "FA2 token")) ;
         Elt "USDT" (Pair 0 "USDT" (Some "KT1H9hKtcqcMHuCoaisu8Qy7wutoUPFELcLm") 6 (Some "FA2 token")) ;
         Elt "tzBTC"

--- a/batcher/batcher.mligo
+++ b/batcher/batcher.mligo
@@ -393,7 +393,7 @@ let remove_batch_holding
 [@inline]
 let can_batch_be_removed
   (batch_number: nat)
-  (batch_holdings: batch_holdings): bool = Big_map.mem batch_number batch_holdings
+  (batch_holdings: batch_holdings): bool = not Big_map.mem batch_number batch_holdings
 
 end
 

--- a/batcher/storage/initial_storage_ghostnet.mligo
+++ b/batcher/storage/initial_storage_ghostnet.mligo
@@ -56,6 +56,7 @@ let f(_:unit) : Batcher.Storage.t = {
   };
   last_order_number = 0n;
   user_batch_ordertypes = (Big_map.empty: Batcher.user_batch_ordertypes);
+  batch_holdings = (Big_map.empty: Batcher.batch_holdings);
   fee_in_mutez = 10_000mutez;
   fee_recipient = ("tz1burnburnburnburnburnburnburjAYjjX" :  address);
   administrator = ("tz1aSL2gjFnfh96Xf1Zp4T36LxbzKuzyvVJ4" : address);

--- a/batcher/storage/initial_storage_mainnet.mligo
+++ b/batcher/storage/initial_storage_mainnet.mligo
@@ -56,6 +56,7 @@ let f(_:unit) : Batcher.Storage.t = {
   };
   last_order_number = 0n;
   user_batch_ordertypes = (Big_map.empty: Batcher.user_batch_ordertypes);
+  batch_holdings = (Big_map.empty: Batcher.batch_holdings);
   fee_in_mutez = 10_000mutez;
   fee_recipient = ("tz1burnburnburnburnburnburnburjAYjjX" :  address);
   administrator = ("tz1aSL2gjFnfh96Xf1Zp4T36LxbzKuzyvVJ4" : address);


### PR DESCRIPTION
We keep the holdings in a big_map keyed by address and then by batch number (i.e. batches per user).  This makes trying to determine if a batch is empty quite tricky.  In this PR we add an additional big_map keyed on batch number that  contains the count of unique address for a given batch that have holdings.  We increment this on deposit and decrement on redemption (based on the assumption that all a users holdings for a given batch are redeemed all at once).  After each decrement (in a redemption), if there are no more holdings, the batch is cleared from both the holdings and the batches bigmaps. 